### PR TITLE
Fix access checks for API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .cache.json
 docker-compose.override.yml
 demo/local.json
+demo/APIKEY.txt

--- a/ep.json
+++ b/ep.json
@@ -4,6 +4,7 @@
       "name": "ep_weave",
       "hooks": {
         "expressCreateServer" : "ep_weave/index:registerRoute",
+        "preAuthorize": "ep_weave/index",
         "eejsBlock_styles": "ep_weave/client"
       },
       "client_hooks": {

--- a/index.js
+++ b/index.js
@@ -100,6 +100,22 @@ async function updateHashes(searchEngine, oldtitle, newtitle) {
   };
 }
 
+exports.preAuthorize = (hookNmae, args, cb) => {
+  const { req } = args;
+  const m = req.originalUrl.match(/^\/ep_weave(\/.+)/);
+  if (!m) {
+    cb();
+    return;
+  }
+  const path = m[1];
+  if (path.match(/^\/api\/.+/)) {
+    console.debug(logPrefix, 'preAuthorize: Grant access for API', req.originalUrl);
+    cb(true);
+    return;
+  }
+  cb();
+};
+
 exports.registerRoute = (hookName, args, cb) => {
   const pluginSettings = settings.ep_search || {};
   const searchEngine = createSearchEngine(pluginSettings);
@@ -134,7 +150,7 @@ exports.registerRoute = (hookName, args, cb) => {
         });
   };
   const {app} = args;
-  app.get('/api/ep_weave/search', apikeyChecker, searchHandler);
+  app.get('/ep_weave/api/search', apikeyChecker, searchHandler);
   app.get('/t/:title', (req, res) => {
     const {title} = req.params;
     getPadIdsByTitle(searchEngine, title)


### PR DESCRIPTION
API endpoints should be authenticated by `APIKEY.txt`, so it is necessary to bypass the authentication process of authentication plugins such as OpenID Connect.