### PR TITLE
Disable clearauthorship by default

### DIFF
--- a/demo/settings.json
+++ b/demo/settings.json
@@ -616,7 +616,7 @@
       ["showusers"]
     ],
     "timeslider": [
-      ["timeslider_export", "timeslider_returnToPad"]
+      ["timeslider_export", "timeslider_settings", "timeslider_returnToPad"]
     ]
   },
 

--- a/demo/settings.json
+++ b/demo/settings.json
@@ -263,7 +263,6 @@
     "cmdShiftL": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_L:true}", /* unordered list */
     "cmdShiftN": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_N:true}", /* ordered list */
     "cmdShift1": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_1:true}", /* ordered list */
-    "cmdShiftC": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_C:true}", /* clear authorship */
     "cmdH":      "${PAD_SHORTCUTS_ENABLED_CMD_H:true}",       /* backspace */
     "ctrlHome":  "${PAD_SHORTCUTS_ENABLED_CTRL_HOME:true}",   /* scroll to top of pad */
     "pageUp":    "${PAD_SHORTCUTS_ENABLED_PAGE_UP:true}",
@@ -604,17 +603,12 @@
 
   /*
    * Toolbar buttons configuration.
-   *
-   * Uncomment to customize.
    */
-
-  /*
   "toolbar": {
     "left": [
       ["bold", "italic", "underline", "strikethrough"],
       ["orderedlist", "unorderedlist", "indent", "outdent"],
-      ["undo", "redo"],
-      ["clearauthorship"]
+      ["undo", "redo"]
     ],
     "right": [
       ["importexport", "timeslider", "savedrevision"],
@@ -625,7 +619,6 @@
       ["timeslider_export", "timeslider_returnToPad"]
     ]
   },
-  */
 
   /*
    * Expose Etherpad version in the web interface and in the Server http header.


### PR DESCRIPTION
Disable clearauthorship by default

- Disable cmd+shift+C to prevent clearauthorship
- Remove clearauthorship button from toolbar