### PR TITLE
Set editOnly to true to prohibit new Pad creation via `/p/xxxx` URL.

### DIFF
--- a/demo/settings.json
+++ b/demo/settings.json
@@ -285,8 +285,10 @@
    *
    * Pad creation is only via the API.
    * This applies both to group pads and regular pads.
+   *
+   * ep_weave does not allow new Pad creation by `/p/xxxx` URL.
    */
-  "editOnly": "${EDIT_ONLY:false}",
+  "editOnly": "true",
 
   /*
    * If true, all css & js will be minified before sending to the client.


### PR DESCRIPTION
Set editOnly to true to prohibit new Pad creation via `/p/xxxx` URL.