### PR TITLE
Fix history corruption on title updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
-        "@types/jquery": "^3.5.29",
+        "@types/jquery": "^3.5.30",
         "@types/node": "^20.11.30",
         "eslint": "^8.11.0",
         "eslint-config-etherpad": "^3.0.9",
@@ -620,9 +620,9 @@
       "dev": true
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
-      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.30.tgz",
+      "integrity": "sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==",
       "dev": true,
       "dependencies": {
         "@types/sizzle": "*"
@@ -12786,9 +12786,9 @@
       "dev": true
     },
     "@types/jquery": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
-      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.30.tgz",
+      "integrity": "sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
-    "@types/jquery": "^3.5.29",
+    "@types/jquery": "^3.5.30",
     "@types/node": "^20.11.30",
     "eslint": "^8.11.0",
     "eslint-config-etherpad": "^3.0.9",

--- a/src/pad/database/text.ts
+++ b/src/pad/database/text.ts
@@ -1,0 +1,59 @@
+const api = require("ep_etherpad-lite/node/db/API");
+const padMessageHandler = require("ep_etherpad-lite/node/handler/PadMessageHandler");
+const CustomError = require('ep_etherpad-lite/node/utils/customError');
+const padManager = require('ep_etherpad-lite/node/db/PadManager');
+
+// based on https://github.com/ether/etherpad-lite/blob/develop/src/node/db/API.ts
+// ... This is required to use spliceText, which is not exported in the API
+
+// gets a pad safe
+const getPadSafe = async (padID: string|object, shouldExist: boolean, text?:string, authorId:string = '') => {
+  // check if padID is a string
+  if (typeof padID !== 'string') {
+    throw new CustomError('padID is not a string', 'apierror');
+  }
+
+  // check if the padID maches the requirements
+  if (!padManager.isValidPadId(padID)) {
+    throw new CustomError('padID did not match requirements', 'apierror');
+  }
+
+  // check if the pad exists
+  const exists = await padManager.doesPadExists(padID);
+
+  if (!exists && shouldExist) {
+    // does not exist, but should
+    throw new CustomError('padID does not exist', 'apierror');
+  }
+
+  if (exists && !shouldExist) {
+    // does exist, but shouldn't
+    throw new CustomError('padID does already exist', 'apierror');
+  }
+
+  // pad exists, let's get it
+  return padManager.getPad(padID, text, authorId);
+};
+
+export type ReplaceSet = {
+  start: number;
+  ndel: number;
+  text: string;
+};
+
+export async function applyReplaceSet(
+  padID: string,
+  replaceSet: ReplaceSet[],
+  authorId: string = ""
+) {
+  const pad = await getPadSafe(padID, true);
+
+  const sortedReplaceSet = new Array<ReplaceSet>(...replaceSet)
+    .sort((a, b) => a.start - b.start)
+    .reverse();
+  for (const replaceSet of sortedReplaceSet) {
+    const { start, ndel, text } = replaceSet;
+    await pad.spliceText(start, ndel, text, authorId);
+  }
+  await padMessageHandler.updatePadClients(pad);
+}

--- a/src/pad/templates/index.html
+++ b/src/pad/templates/index.html
@@ -17,6 +17,9 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js">
 </script>
 
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous">
+</script>
+
 <script type="text/javascript">
   $(document).ready(function(){
     require(['index/index'], function(index) {


### PR DESCRIPTION
Fix #27

Fixed history corruption when updating titles; instead of using the setHTML API, it calls the spliceText to replace only the part that has changed.
Also, the latest Etherpad image had JQuery removed from the Global namespace, which was causing the index to not work and fixed it.