### PR TITLE
Fix misalignment of replacements when updating hashes after itemized text

### DIFF
--- a/src/pad/database/hash.ts
+++ b/src/pad/database/hash.ts
@@ -2,7 +2,7 @@ import { SearchEngine, PadType } from "ep_search/setup";
 import { tokenize } from "../static/js/parser";
 import { logPrefix } from "../util/log";
 import { getHashQuery } from "../static/js/hash";
-import { applyReplaceSet, ReplaceSet } from "./text";
+import { applyReplaceSet, ReplaceSet, getAText } from "./text";
 
 const api = require("ep_etherpad-lite/node/db/API");
 const { decode, encode } = require("he");
@@ -62,7 +62,7 @@ function replaceHash(text: string, updates: HashUpdate[]): ReplaceSet[] {
 }
 
 export async function updateHash(padId: string, updates: HashUpdate[]) {
-  const { text } = await api.getText(padId);
+  const { text } = await getAText(padId);
   console.debug(
     logPrefix,
     "Update hash with text",

--- a/src/pad/database/text.ts
+++ b/src/pad/database/text.ts
@@ -57,3 +57,8 @@ export async function applyReplaceSet(
   }
   await padMessageHandler.updatePadClients(pad);
 }
+
+export async function getAText(padID: string) {
+  const pad = await getPadSafe(padID, true);
+  return pad.atext;
+}

--- a/src/pad/database/title.ts
+++ b/src/pad/database/title.ts
@@ -3,7 +3,7 @@ import removeMdBase from "remove-markdown";
 import { searchHashes, updateHash } from "./hash";
 import { logPrefix } from "../util/log";
 import { escapeForText } from "../static/js/result";
-import { applyReplaceSet, ReplaceSet } from "./text";
+import { applyReplaceSet, ReplaceSet, getAText } from "./text";
 
 const api = require("ep_etherpad-lite/node/db/API");
 const db = require("ep_etherpad-lite/node/db/DB").db;
@@ -67,7 +67,7 @@ async function updateTitleContent(
   newTitle: string
 ): Promise<TitleUpdateResult> {
   console.info(logPrefix, "Update title", pad.id, oldTitle, newTitle);
-  const { text } = await api.getText(pad.id);
+  const { text } = await getAText(pad.id);
   const replaceSet = replaceTitle(text, oldTitle, newTitle);
   if (replaceSet === null) {
     console.warn(logPrefix, "Title not found in HTML", oldTitle, newTitle);


### PR DESCRIPTION
This PR addresses an issue with the misalignment of text replacements that occurs when updating hashes after itemized content is processed. To resolve the issue, I have implemented the getAText function that returns the raw text without any formatted characters or items instead of the api.getText function.