### PR TITLE
Support for subdirectories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ USER root
 COPY --from=build-stage /app/ep_weave /tmp/ep_weave
 
 # ep_search
-RUN git clone -b feature/search-engine-ep2 https://github.com/yacchin1205/ep_search.git /tmp/ep_search \
+RUN git clone -b feature/search-engine https://github.com/NII-cloud-operation/ep_search.git /tmp/ep_search \
     && cd /tmp/ep_search \
     && ls -la /tmp/ep_search \
     && npm pack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+ARG ETHERPAD_IMAGE_NAME="etherpad/etherpad"
+ARG ETHERPAD_IMAGE_TAG="2"
+
 FROM mcr.microsoft.com/devcontainers/typescript-node:18 AS build-stage
 
 COPY . /app/ep_weave
@@ -5,7 +8,7 @@ RUN cd /app/ep_weave \
     && ls -la /app/ep_weave \
     && npm i --include dev && npm run build
 
-FROM etherpad/etherpad:2
+FROM ${ETHERPAD_IMAGE_NAME}:${ETHERPAD_IMAGE_TAG}
 
 USER root
 

--- a/src/pad/index.ts
+++ b/src/pad/index.ts
@@ -17,6 +17,10 @@ const api = require("ep_etherpad-lite/node/db/API");
 
 let apikey: string | null = null;
 
+type PluginSettings = {
+  basePath?: string;
+};
+
 async function getPadIdsByTitle(searchEngine: SearchEngine, title: string) {
   const results = await searchEngine.search(
     `title:"${escapeForText(title)}"`
@@ -81,6 +85,8 @@ exports.registerRoute = (
   args: ExpressCreateServerArgs,
   cb: (next: any) => void
 ) => {
+  const epWeavePluginSettings = (settings.ep_weave || {}) as PluginSettings;
+  const basePath = epWeavePluginSettings.basePath || "";
   const pluginSettings = settings.ep_search || {};
   const searchEngine = createSearchEngine(pluginSettings);
   const apikeyFilename = absolutePaths.makeAbsolute(
@@ -141,7 +147,7 @@ exports.registerRoute = (
         if (ids === null) {
           createNewPadForTitle(title, req)
             .then((id) => {
-              res.redirect(`/p/${id}`);
+              res.redirect(`${basePath}/p/${id}`);
             })
             .catch((err) => {
               console.error(
@@ -155,7 +161,7 @@ exports.registerRoute = (
             });
           return;
         }
-        res.redirect(`/p/${ids[0]}`);
+        res.redirect(`${basePath}/p/${ids[0]}`);
       })
       .catch((err) => {
         console.error(

--- a/src/pad/static/js/hashitem.ts
+++ b/src/pad/static/js/hashitem.ts
@@ -1,5 +1,6 @@
 import { PadType } from "ep_search/setup";
 import { getColorFromTitle, contrastRatio } from "./color";
+import { getBasePath } from "./util";
 
 function mostReadableColor(backgroundColor: string, colorCandidates: string[]) {
   const contrastRatios = colorCandidates.map((color) =>
@@ -25,9 +26,9 @@ export async function createHashItemView(doc: PadType) {
     "#cccccc",
     "#ffffff",
   ]);
-
+  const basePath = getBasePath();
   const anchor = $("<a></a>")
-    .attr("href", `/p/${value}`)
+    .attr("href", `${basePath}/p/${value}`)
     .css("color", color)
     .text(title);
   const hashLink = $("<div></div>")

--- a/src/pad/static/js/hashview.ts
+++ b/src/pad/static/js/hashview.ts
@@ -12,6 +12,7 @@ import { query, escapeForText } from "./result";
 import { createToolbar, createCloseButton } from "./toolbar";
 import { initResizer, windowResized } from "./resizer";
 import { getHashQuery } from "./hash";
+import { getBasePath } from "./util";
 
 type PadRef = {
   id: string;
@@ -47,7 +48,8 @@ function getPadURL() {
   const url = new URL(window.location.href);
   url.search = "";
   url.hash = "";
-  url.pathname = `/t/${encodeURIComponent(ep_weave.title)}`;
+  const basePath = getBasePath();
+  url.pathname = `${basePath}/t/${encodeURIComponent(ep_weave.title)}`;
   return url.toString();
 }
 
@@ -83,10 +85,11 @@ function overrideEmbedCommand(toolbar: AceToolbar) {
 }
 
 function refreshNavbar(navbar: JQuery, title: string) {
+  const basePath = getBasePath();
   navbar.empty();
   navbar.append(
     $("<a>")
-      .attr("href", "/")
+      .attr("href", `${basePath}/`)
       .text("Index")
       .addClass("hashview-path-segment hashview-path-index")
   );
@@ -99,7 +102,7 @@ function refreshNavbar(navbar: JQuery, title: string) {
       $("<a>")
         .addClass("hashview-path-segment")
         .text(segment)
-        .attr("href", `/t/${encodeURIComponent(parentPath)}`)
+        .attr("href", `${basePath}/t/${encodeURIComponent(parentPath)}`)
     );
     navbar.append($("<span>").addClass("hashview-path-separator").text("/"));
   }
@@ -175,8 +178,9 @@ function createMenuItem() {
         return;
       }
       duplicatedPads.forEach((pad) => {
+        const basePath = getBasePath();
         console.debug(logPrefix, "Open pad", pad);
-        window.open(`/p/${pad.id}`, "_blank");
+        window.open(`${basePath}/p/${pad.id}`, "_blank");
       });
     });
   return $("<li></li>")
@@ -332,10 +336,11 @@ async function loadHashView(
   (await Promise.all(hashViews)).forEach((hashView) => {
     container.append(hashView);
   });
+  const basePath = getBasePath();
   const titledPadExists = docs.some((doc) => doc.title === hash.substring(1));
   if (title !== hash.substring(1) && !titledPadExists) {
     const anchor = $("<a></a>")
-      .attr("href", `/t/${hash.substring(1)}`)
+      .attr("href", `${basePath}/t/${hash.substring(1)}`)
       .text(hash.substring(1));
     const createClass = "hash-create";
     const hashLink = $("<div></div>")
@@ -505,7 +510,8 @@ exports.postToolbarInit = (hook: any, context: PostToolbarInit) => {
             title += "/";
           }
           title += query;
-          window.open(`/t/${encodeURIComponent(title)}`, "_blank");
+          const basePath = getBasePath();
+          window.open(`${basePath}/t/${encodeURIComponent(title)}`, "_blank");
         },
       }).prepend($("<div>").text(">").addClass("hashview-toolbar-child-marker"))
     )
@@ -577,9 +583,10 @@ export function aceCreateDomLine(
   if (!hashTitle) {
     throw new Error(`Unexpected error: ${searchHash_}, ${hash}, ${link}`);
   }
+  const basePath = getBasePath();
   return [
     {
-      extraOpenTags: `<a href="/t/${encodeURIComponent(hashTitle)}">`,
+      extraOpenTags: `<a href="${basePath}/t/${encodeURIComponent(hashTitle)}">`,
       extraCloseTags: "</a>",
       cls: modifiedCls,
     },

--- a/src/pad/static/js/hashview.ts
+++ b/src/pad/static/js/hashview.ts
@@ -132,6 +132,7 @@ function getCurrentSort() {
 }
 
 function createMenuItem() {
+  const basePath = getBasePath();
   const changeTitleButton = $("<button></button>")
     .addClass("hashview-change-title btn")
     .on("click", () => {
@@ -139,7 +140,7 @@ function createMenuItem() {
         return;
       }
       $.ajax({
-        url: `/ep_weave/hashes?${new URLSearchParams({
+        url: `${basePath}/ep_weave/hashes?${new URLSearchParams({
           oldtitle: changedTitle.oldtitle,
           newtitle: changedTitle.newtitle,
         })}`,

--- a/src/pad/static/js/result.ts
+++ b/src/pad/static/js/result.ts
@@ -1,4 +1,5 @@
 import { SearchResponse } from "ep_search/setup";
+import { getBasePath } from "./util";
 
 export function escapeForText(query: string): string {
   let escaped = query;
@@ -34,8 +35,9 @@ export function query(
     if (rows !== undefined) {
       opts.push(`&rows=${rows}`);
     }
+    const basePath = getBasePath();
     $.getJSON(
-      `/search/?query=${encodeURIComponent(query)}${opts.join("")}`,
+      `${basePath}/search/?query=${encodeURIComponent(query)}${opts.join("")}`,
       (data: SearchResponse) => {
         resolve(data);
       }

--- a/src/pad/static/js/toolbar.ts
+++ b/src/pad/static/js/toolbar.ts
@@ -1,3 +1,5 @@
+import { getBasePath } from "./util";
+
 export type Callbacks = {
   onSearch: (query: string) => void;
   onSort: (sort: string) => void;
@@ -82,8 +84,9 @@ function createSearchBox(
     if (typeof query !== "string") {
       return;
     }
+    const basePath = getBasePath();
     if (!onCreate) {
-      window.open(`/t/${encodeURIComponent(query)}`, "_blank");
+      window.open(`${basePath}/t/${encodeURIComponent(query)}`, "_blank");
       return;
     }
     onCreate(query);

--- a/src/pad/static/js/util.ts
+++ b/src/pad/static/js/util.ts
@@ -1,0 +1,19 @@
+export function getBasePath() {
+  // The path is in the form of .../p/id or .../t/title, so get the part before that
+  const path = window.location.pathname;
+  let index = path.indexOf("/p/");
+  if (index < 0) {
+    index = path.indexOf("/t/");
+    if (index < 0) {
+      console.warn("Base path not found", path);
+      // remove the last part of the path
+      const lastSlash = path.lastIndexOf("/");
+      if (lastSlash >= 0) {
+        return path.substring(0, lastSlash);
+      } else {
+        return "";
+      }
+    }
+  }
+  return path.substring(0, index);
+}

--- a/src/pad/templates/index.html
+++ b/src/pad/templates/index.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="../static/plugins/ep_weave/static/css/index.css" type="text/css" />
-<link rel="stylesheet" href="../static/plugins/ep_weave/static/css/styles.css" type="text/css" />
+<link rel="stylesheet" href="./static/plugins/ep_weave/static/css/index.css" type="text/css" />
+<link rel="stylesheet" href="./static/plugins/ep_weave/static/css/styles.css" type="text/css" />
 
 <div id="weave-index">
   <div class="weave-toolbar">
@@ -16,6 +16,9 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js">
 </script>
+<script src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
+  integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8="
+  crossorigin="anonymous"></script>
 
 <script type="text/javascript">
   $(document).ready(function(){


### PR DESCRIPTION
To integrate ep_weave into OperationHub, modify it to work under the subdirectory `/services/xyz`.

- ep_weave.basePath is added to settings. If you specify something like `/services/ep_weave` here, it will adjust the endpoint URL to be under that directory.
- Path names in the code have been modified to allow for subdirectories.
- Base image can be changed by buildarg. As of 2024-09-03, `etherpad/etherpad:2` does not support subdirectories, so you must specify `etherpad/etherpad:develop`.
- The error was caused by jquery not being found, so we added it in the form of loading it from CDN.(Temporary solution)