### PR TITLE
Add support for notebook search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ETHERPAD_IMAGE_NAME="etherpad/etherpad"
-ARG ETHERPAD_IMAGE_TAG="2"
+ARG ETHERPAD_IMAGE_TAG="2.4"
 
 FROM mcr.microsoft.com/devcontainers/typescript-node:18 AS build-stage
 

--- a/docs/notebook-search.md
+++ b/docs/notebook-search.md
@@ -1,0 +1,50 @@
+# Notebook Search
+
+## Configuration
+
+Add to `settings.json`:
+
+```json
+{
+  "ep_weave": {
+    "notebookSearch": {
+      "baseUrl": "https://solr-server:8983",
+      "core": "jupyter-cell",
+      "username": "optional",
+      "password": "optional",
+      "jupyterBaseUrl": "https://jupyter.example.com/user/username"
+    }
+  }
+}
+```
+
+- `baseUrl` (required): Solr server URL
+- `core` (optional): Solr core name, default: "jupyter-cell"
+- `username`/`password` (optional): Basic authentication
+- `jupyterBaseUrl` (optional): Jupyter server base URL for notebook links
+
+## Features
+
+- Searches Jupyter notebook markdown headings (`source__markdown__heading` field)
+- Displays results in Rollup area under "Notebooks with this keyword in headings"
+- Shows: filename, heading text, cell number, modification date
+
+## API
+
+`GET /ep_weave/notebook-search`
+
+Query parameters:
+- `query` or `q`: Search keyword
+- `start`: Offset (default: 0)
+- `limit`: Result count (default: 60)
+- `sort`: Sort order (default: "notebook_mtime desc")
+
+## Behavior
+
+- If not configured: endpoint returns 404, no UI section shown
+- If configured: searches Solr and displays results in Rollup
+
+## Notes
+
+- Notebook links use nbsearch plugin with `lc_cell_meme__current` field to highlight specific cells
+- Links are only generated when `jupyterBaseUrl` is configured

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/express": "^4.17.21",
         "@types/jquery": "^3.5.30",
         "@types/node": "^20.11.30",
+        "@types/node-fetch": "^2.6.13",
         "eslint": "^8.57.0",
         "eslint-config-etherpad": "^4.0.4",
         "typescript": "^5.4.2"
@@ -332,6 +333,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/qs": {
@@ -1044,6 +1056,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1217,6 +1236,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1380,6 +1412,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -2312,6 +2354,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3276,6 +3335,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/express": "^4.17.21",
     "@types/jquery": "^3.5.30",
     "@types/node": "^20.11.30",
+    "@types/node-fetch": "^2.6.13",
     "eslint": "^8.57.0",
     "eslint-config-etherpad": "^4.0.4",
     "typescript": "^5.4.2"

--- a/src/common/@types/ep_etherpad-lite/hooks.d.ts
+++ b/src/common/@types/ep_etherpad-lite/hooks.d.ts
@@ -16,6 +16,8 @@ declare module "ep_etherpad-lite/hooks" {
   export type ClientVars = {
     ep_weave: {
       toggleRollupKey?: string;
+      notebookSearchEnabled?: boolean;
+      jupyterBaseUrl?: string;
       title?: string;
       oldTitle?: string;
       titleChangedChecked?: any;

--- a/src/index/index.ts
+++ b/src/index/index.ts
@@ -4,12 +4,41 @@ import { createToolbar } from "../pad/static/js/toolbar";
 
 const LIMIT_ITEMS = 60;
 
+function updateURL(queryString?: string, sort?: string) {
+  const url = new URL(window.location.href);
+  
+  // Use query parameters instead of path
+  if (queryString && queryString !== "*") {
+    url.searchParams.set("q", queryString);
+  } else {
+    url.searchParams.delete("q");
+  }
+  
+  if (sort && sort !== "indexed desc") {
+    url.searchParams.set("sort", sort);
+  } else {
+    url.searchParams.delete("sort");
+  }
+  
+  window.history.replaceState({}, "", url.toString());
+}
+
+function getURLParams() {
+  const url = new URL(window.location.href);
+  
+  return {
+    query: url.searchParams.get("q") || undefined,
+    sort: url.searchParams.get("sort") || undefined,
+  };
+}
+
 async function updateIndex(
   container: JQuery,
   queryString?: string,
   start?: number,
   rows?: number,
-  sort?: string
+  sort?: string,
+  updateUrl: boolean = true
 ) {
   const result = await query(
     queryString || "*",
@@ -17,6 +46,9 @@ async function updateIndex(
     rows === undefined ? LIMIT_ITEMS : rows,
     sort
   );
+  if (updateUrl && start === 0) {
+    updateURL(queryString, sort);
+  }
   container.empty();
   for (const hashView of await Promise.all(
     result.docs.map((doc) => createHashItemView(doc))
@@ -35,7 +67,8 @@ async function updateIndex(
           queryString,
           result.start + result.docs.length,
           rows,
-          sort
+          sort,
+          false
         )
           .then(() => {
             console.log("Index updated");
@@ -65,42 +98,59 @@ function closeErrorMessage() {
 
 export default function init() {
   const rootContainer = $("#weave-index .weave-container");
+  let urlParams = getURLParams();
+  let currentQuery = urlParams.query;
+  let currentSort = urlParams.sort || "indexed desc";
+  
   $("#weave-error-close").on("click", () => {
     closeErrorMessage();
   });
+  
+  const toolbar = createToolbar({
+    onSort: (sort) => {
+      currentSort = sort;
+      updateIndex(rootContainer, currentQuery, 0, LIMIT_ITEMS, sort)
+        .then(() => {
+          console.log("Index updated");
+        })
+        .catch((err) => {
+          showErrorMessage(
+            `Error retrieving index: ${
+              err.stack || err.message || String(err)
+            }`
+          );
+        });
+    },
+    onSearch: (query) => {
+      currentQuery = query;
+      updateIndex(rootContainer, query, 0, LIMIT_ITEMS, currentSort)
+        .then(() => {
+          console.log("Index updated");
+        })
+        .catch((err) => {
+          showErrorMessage(
+            `Error retrieving index: ${
+              err.stack || err.message || String(err)
+            }`
+          );
+        });
+    },
+  });
+  
   $("#weave-index .weave-toolbar")
     .append($("<div>").text("ep_weave").addClass("weave-title"))
-    .append(
-      createToolbar({
-        onSort: (sort) => {
-          updateIndex(rootContainer, undefined, 0, LIMIT_ITEMS, sort)
-            .then(() => {
-              console.log("Index updated");
-            })
-            .catch((err) => {
-              showErrorMessage(
-                `Error retrieving index: ${
-                  err.stack || err.message || String(err)
-                }`
-              );
-            });
-        },
-        onSearch: (query) => {
-          updateIndex(rootContainer, query)
-            .then(() => {
-              console.log("Index updated");
-            })
-            .catch((err) => {
-              showErrorMessage(
-                `Error retrieving index: ${
-                  err.stack || err.message || String(err)
-                }`
-              );
-            });
-        },
-      })
-    );
-  updateIndex(rootContainer)
+    .append(toolbar);
+  
+  // Initialize search box and sort selection from URL parameters
+  if (urlParams.query) {
+    toolbar.find(".hashview-search-box").val(urlParams.query);
+    toolbar.find("button").last().attr("disabled", null);
+  }
+  if (urlParams.sort) {
+    toolbar.find("#hashview-order").val(urlParams.sort);
+  }
+  
+  updateIndex(rootContainer, urlParams.query, 0, LIMIT_ITEMS, urlParams.sort, false)
     .then(() => {
       console.log("Index updated");
     })

--- a/src/pad/index.ts
+++ b/src/pad/index.ts
@@ -303,9 +303,10 @@ function performRegisterRoute(
   };
 
   app.get("/ep_weave/notebook-search", notebookSearchHandler);
-  app.get("/t/:title(*)", (req, res) => {
+  // Use regex directly for version compatibility
+  app.get(/^\/t\/(.*)/, (req: Request, res: Response) => {
     const { user } = (req as any).session;
-    const { title } = req.params;
+    const title = req.params[0] || '';
     getPadIdsByTitle(searchEngine, title)
       .then((ids) => {
         if (ids === null) {

--- a/src/pad/solr-client.ts
+++ b/src/pad/solr-client.ts
@@ -1,0 +1,82 @@
+import fetch, { Headers } from 'node-fetch';
+
+interface SolrClientConfig {
+  baseUrl: string;
+  core?: string;
+  username?: string;
+  password?: string;
+}
+
+interface SolrQuery {
+  q: string;
+  start?: number;
+  rows?: number;
+  sort?: string;
+}
+
+interface SolrResponse {
+  response: {
+    docs: any[];
+    numFound: number;
+    start: number;
+    numFoundExact?: boolean;
+  };
+}
+
+export function createClient(config: SolrClientConfig) {
+  const { baseUrl, core = 'jupyter-cell' } = config;
+  let authHeader: string | null = null;
+
+  // Remove trailing slash from baseUrl if present
+  const cleanBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  const solrUrl = `${cleanBaseUrl}/solr/${core}`;
+
+  return {
+    basicAuth(username: string, password: string) {
+      authHeader = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+    },
+
+    async search(query: SolrQuery): Promise<SolrResponse> {
+      const params = new URLSearchParams({
+        q: query.q,
+        wt: 'json',
+        start: (query.start || 0).toString(),
+        rows: (query.rows || 10).toString(),
+      });
+
+      if (query.sort) {
+        params.append('sort', query.sort);
+      }
+
+      const headers = new Headers({
+        'Content-Type': 'application/json',
+      });
+
+      if (authHeader) {
+        headers.append('Authorization', authHeader);
+      }
+
+      const url = `${solrUrl}/select?${params}`;
+      console.debug('[ep_weave/solr-client] Solr request URL:', url);
+      console.debug('[ep_weave/solr-client] Solr query:', query);
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+      });
+
+      if (!response.ok) {
+        const responseText = await response.text();
+        console.error('[ep_weave/solr-client] Solr error response:', {
+          status: response.status,
+          statusText: response.statusText,
+          url,
+          responseBody: responseText,
+        });
+        throw new Error(`Solr search failed: ${response.status} ${response.statusText} - ${responseText}`);
+      }
+
+      return await response.json();
+    },
+  };
+}

--- a/src/pad/static/css/index.css
+++ b/src/pad/static/css/index.css
@@ -1,3 +1,7 @@
+#wrapper {
+    max-width: none !important;
+}
+
 #inner {
     display: none;
 }

--- a/src/pad/static/css/styles.css
+++ b/src/pad/static/css/styles.css
@@ -10,6 +10,20 @@
     display: none;
 }
 
+.hash-title.notebook-title a {
+    /* Override default hash-title styles - use line clamping */
+    display: -webkit-box;
+    line-clamp: 2;
+    -webkit-line-clamp: 2; /* Limit to 2 lines */
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    overflow-wrap: break-all;
+    word-wrap: break-all; /* Legacy support */
+    word-break: break-all;
+}
+
 .hashview {
     background-color: white;
     position: absolute;

--- a/src/pad/static/js/hashview.ts
+++ b/src/pad/static/js/hashview.ts
@@ -21,6 +21,7 @@ type PadRef = {
 type RelatedHash = {
   displayName: string;
   hash: string;
+  type?: 'pads' | 'cells';
 };
 
 const logPrefix = "[ep_weave/hashview]";
@@ -34,6 +35,7 @@ const ACE_EDITOR_MODIFIER_PATTERN = /(^| )searchHash:(\S+)/g;
 const ACE_EDITOR_CLASS = "hashview-editor-link";
 const MAX_OPEN_DUPLICATED_PADS = 3;
 const LIMIT_HASH_VIEW_ITEMS = 60;
+const LIMIT_CELLS_VIEW_ITEMS = 10;
 
 function updateTitle(title: string) {
   document.title = `${title} | EP\u{1F9F6}\u{1FAA1}`;
@@ -103,14 +105,14 @@ function toggleHashView() {
 function handleKeyboardShortcut(event: KeyboardEvent, source: string): boolean {
   try {
     const toggleRollupKey = clientVars.ep_weave && clientVars.ep_weave.toggleRollupKey;
-    
+
     // If toggleRollupKey is not set or empty, disable keyboard shortcuts
     if (!toggleRollupKey || toggleRollupKey.trim() === "") {
       return false;
     }
-    
+
     const keyCombination = parseKeyCombination(toggleRollupKey);
-    
+
     if (matchesKeyEvent(event, keyCombination)) {
       event.preventDefault();
       event.stopPropagation();
@@ -121,7 +123,7 @@ function handleKeyboardShortcut(event: KeyboardEvent, source: string): boolean {
   } catch (error) {
     console.error(logPrefix, "Error parsing key combination:", error);
   }
-  
+
   return false; // Event not handled
 }
 
@@ -332,7 +334,7 @@ async function loadChildPads(
   return !empty;
 }
 
-async function loadHashView(
+async function loadPadsHashView(
   title: string,
   hash: string,
   additionalQuery: string | null,
@@ -385,6 +387,146 @@ async function loadHashView(
   return !empty;
 }
 
+async function loadCellsHashView(
+  title: string,
+  hash: string,
+  additionalQuery: string | null,
+  limit: number,
+  sort: string | undefined,
+  container: JQuery
+): Promise<void> {
+  const basePath = getBasePath();
+  const keyword = hash.substring(1); // Remove # prefix
+
+  // Translate pad sort fields to notebook sort fields
+  let notebookSort = sort;
+  if (sort) {
+    const sortParts = sort.split(' ');
+    const field = sortParts[0];
+    const order = sortParts[1] || 'desc';
+
+    const fieldMap: { [key: string]: string } = {
+      'indexed': 'notebook_mtime',
+      'title': 'notebook_filename',
+    };
+
+    const mappedField = fieldMap[field] || field;
+    notebookSort = `${mappedField} ${order}`;
+  }
+
+  try {
+    let url = `${basePath}/ep_weave/notebook-search?query=${encodeURIComponent(keyword)}`;
+    if (notebookSort) {
+      url += `&sort=${encodeURIComponent(notebookSort)}`;
+    }
+    if (limit) {
+      url += `&limit=${limit}`;
+    }
+
+    const response = await $.getJSON(url);
+
+    if (response.docs && response.docs.length > 0) {
+      response.docs.forEach((doc: any) => {
+        const notebookItem = $("<div>").addClass("hash-link notebook-item");
+
+        // Generate link to notebook with nbsearch
+        let notebookUrl = "#";
+        const jupyterBaseUrl = clientVars.ep_weave?.jupyterBaseUrl;
+        if (jupyterBaseUrl) {
+          let solrQuery;
+          if (doc.lc_cell_meme__current) {
+            // Use cell ID if available
+            solrQuery = `q.op=AND&q=lc_cell_memes:${doc.lc_cell_meme__current}&start=0&rows=50&sort=mtime desc`;
+          } else if (doc.source__markdown__heading) {
+            // Fallback to heading search
+            solrQuery = `q.op=AND&q=source__markdown__heading:"${encodeURIComponent(doc.source__markdown__heading)}"&start=0&rows=50&sort=mtime desc`;
+          } else {
+            // No specific search criteria available
+            console.warn(logPrefix, "No cell ID or heading available for notebook link:", doc.notebook_filename);
+            solrQuery = null;
+          }
+
+          if (solrQuery) {
+            const params = new URLSearchParams({
+              limit: "50",
+              size: "0",
+              start: "0",
+              numFound: "0",
+              sort: "mtime desc",
+              solrquery: solrQuery,
+              error: "",
+              nbsearch: "yes"
+            });
+            notebookUrl = `${jupyterBaseUrl}?${params.toString()}`;
+          }
+        }
+
+        // Extract filename from path
+        const filename = doc.notebook_filename.split('/').pop() || doc.notebook_filename;
+
+        const notebookLink = $("<a>")
+          .attr("href", notebookUrl)
+          .attr("target", "_blank")
+          .attr("title", filename) // Add tooltip with full filename
+          .text(filename);
+
+        const notebookTitle = $("<div>").addClass("hash-title notebook-title").append(notebookLink);
+        notebookItem.append(notebookTitle);
+
+        // Add heading content if available
+        if (doc.source__markdown__heading) {
+          const headingText = $("<div>")
+            .addClass("hash-shorttext")
+            .text(doc.source__markdown__heading);
+          notebookItem.append(headingText);
+        }
+
+        // Add metadata (owner, cell index, modification time)
+        const metadata = $("<div>").addClass("hash-metadata");
+        if (doc.notebook_owner && jupyterBaseUrl) {
+          // Create clickable owner link
+          const ownerSolrQuery = `q.op=AND&q=owner:${doc.notebook_owner}&start=0&rows=50&sort=mtime desc`;
+          const ownerParams = new URLSearchParams({
+            limit: "50",
+            size: "0",
+            start: "0",
+            numFound: "0",
+            sort: "mtime desc",
+            solrquery: ownerSolrQuery,
+            error: "",
+            nbsearch: "yes"
+          });
+          const ownerUrl = `${jupyterBaseUrl}?${ownerParams.toString()}`;
+          const ownerLink = $("<a>")
+            .attr("href", ownerUrl)
+            .attr("target", "_blank")
+            .text(`@${doc.notebook_owner}`);
+          metadata.append(ownerLink);
+        } else if (doc.notebook_owner) {
+          metadata.append($("<span>").text(`@${doc.notebook_owner}`));
+        }
+        if (doc.index !== undefined) {
+          metadata.append($("<span>").text(` · Cell #${doc.index}`));
+        }
+        if (doc.notebook_mtime) {
+          const date = new Date(doc.notebook_mtime);
+          metadata.append($("<span>").text(` · ${date.toLocaleDateString()}`));
+        }
+        if (metadata.children().length > 0) {
+          notebookItem.append(metadata);
+        }
+
+        container.append(notebookItem);
+      });
+    } else {
+      container.append($("<div>").text("No notebooks found"));
+    }
+  } catch (err) {
+    console.error(logPrefix, "Error loading notebook results:", err);
+    container.append($("<div>").text("Error loading notebook results"));
+  }
+}
+
 function reloadHashView(
   title: string,
   hashes: RelatedHash[],
@@ -403,18 +545,30 @@ function reloadHashView(
     childContainer
   );
 
-  const tasks = (hashes || []).map(({ displayName, hash }) => {
+  const tasks = (hashes || []).map(({ displayName, hash, type }) => {
     root.append($("<div></div>").text(displayName).addClass("hash-text"));
     const container = $("<div></div>").addClass("hash-container");
     root.append(container);
-    return loadHashView(
-      title,
-      hash,
-      additionalQuery,
-      LIMIT_HASH_VIEW_ITEMS,
-      sort || undefined,
-      container
-    );
+
+    if (type === 'cells') {
+      return loadCellsHashView(
+        title,
+        hash,
+        additionalQuery,
+        LIMIT_CELLS_VIEW_ITEMS,
+        sort || undefined,
+        container
+      );
+    } else {
+      return loadPadsHashView(
+        title,
+        hash,
+        additionalQuery,
+        LIMIT_HASH_VIEW_ITEMS,
+        sort || undefined,
+        container
+      );
+    }
   });
   Promise.all(tasks).then(() => {});
 }
@@ -448,7 +602,7 @@ exports.postAceInit = (hook: any, context: PostAceInitContext) => {
   updateTitle(title);
   checkTitleDuplicated(title, clientVars);
   addBeforeUnloadListener();
-  
+
   // Add keyboard shortcut handler using ACE's setOnKeyDown
   if (ace.setOnKeyDown) {
     ace.setOnKeyDown((event: KeyboardEvent) => {
@@ -457,16 +611,16 @@ exports.postAceInit = (hook: any, context: PostAceInitContext) => {
   } else {
     console.warn(logPrefix, "ACE setOnKeyDown not found, keyboard shortcuts may not work properly");
   }
-  
+
   // Add document-level keyboard shortcut handler for when ACE is not focused
   document.addEventListener("keydown", (event: KeyboardEvent) => {
     // Only handle if ACE editor is not focused
     const activeElement = document.activeElement;
     const isAceEditor = activeElement && (
-      activeElement.classList.contains("ace_text-input") || 
+      activeElement.classList.contains("ace_text-input") ||
       activeElement.closest(".ace_editor")
     );
-    
+
     if (!isAceEditor) {
       handleKeyboardShortcut(event, "document");
     }
@@ -489,12 +643,27 @@ exports.aceEditEvent = (hook: string, context: AceEditEventContext) => {
   }));
   if (title || myPad) {
     const myHash = `#${title || myPad?.id}`;
-    relatedHashes = [
+    let hashItems: RelatedHash[] = [
       {
         displayName: "Pages referring to this page",
         hash: myHash,
+        type: 'pads' as const,
       },
-    ].concat(relatedHashes.filter(({ hash }) => hash !== myHash));
+    ];
+
+    relatedHashes = hashItems.concat(
+      relatedHashes.filter(({ hash }) => hash !== myHash)
+    );
+
+    // Only add notebook search if enabled
+    if (ep_weave.notebookSearchEnabled) {
+      const notebookItems = hashes.map((hash) => ({
+        displayName: `Notebooks with '${hash}' in headings`,
+        hash,
+        type: 'cells' as const,
+      }));
+      relatedHashes = relatedHashes.concat(notebookItems);
+    }
   }
   if (ep_weave.title !== title && title.length > 0) {
     console.debug(logPrefix, "Title changed", ep_weave.title, title);

--- a/src/pad/static/js/hashview.ts
+++ b/src/pad/static/js/hashview.ts
@@ -436,10 +436,10 @@ async function loadCellsHashView(
           let solrQuery;
           if (doc.lc_cell_meme__current) {
             // Use cell ID if available
-            solrQuery = `q.op=AND&q=lc_cell_memes:${doc.lc_cell_meme__current}&start=0&rows=50&sort=mtime desc`;
+            solrQuery = `lc_cell_memes:${doc.lc_cell_meme__current}`;
           } else if (doc.source__markdown__heading) {
             // Fallback to heading search
-            solrQuery = `q.op=AND&q=source__markdown__heading:"${encodeURIComponent(doc.source__markdown__heading)}"&start=0&rows=50&sort=mtime desc`;
+            solrQuery = `source__markdown__heading:"${doc.source__markdown__heading}"`;
           } else {
             // No specific search criteria available
             console.warn(logPrefix, "No cell ID or heading available for notebook link:", doc.notebook_filename);
@@ -485,7 +485,7 @@ async function loadCellsHashView(
         const metadata = $("<div>").addClass("hash-metadata");
         if (doc.notebook_owner && jupyterBaseUrl) {
           // Create clickable owner link
-          const ownerSolrQuery = `q.op=AND&q=owner:${doc.notebook_owner}&start=0&rows=50&sort=mtime desc`;
+          const ownerSolrQuery = `owner:${doc.notebook_owner}`;
           const ownerParams = new URLSearchParams({
             limit: "50",
             size: "0",


### PR DESCRIPTION
This pull request introduces a new feature for searching Jupyter notebook headings from Etherpad, adds supporting documentation, and enhances the UI to display notebook search results. It also refactors the index page to use URL query parameters for search and sort, and includes several minor improvements for usability and compatibility.

### Notebook search integration

* Added a new `/ep_weave/notebook-search` API endpoint to search Jupyter notebook markdown headings via Solr, including configuration options for authentication and Jupyter links. Returns 404 if not configured. (`src/pad/index.ts`, `src/pad/solr-client.ts`, `docs/notebook-search.md`) [[1]](diffhunk://#diff-04b5980b8dc14454f275c66d812dced154a6990cea9b1143b186031a579c5f16L229-R309) [[2]](diffhunk://#diff-b4118da25e4e5972e9381515731dec50131f468d4dbf2ca5daa6f86398e59a22R1-R82) [[3]](diffhunk://#diff-c6cadd8180b9b12607f201f7e139c7202fdbdecf6225ad8088c8b62b28a793cfR1-R50)
* Updated the client-side hashview to display notebook search results in the Rollup area, showing filename, heading, cell number, and modification date, with links to Jupyter notebooks if configured. (`src/pad/static/js/hashview.ts`, `src/pad/index.ts`) [[1]](diffhunk://#diff-4b4441d6686187d5b1e82556bfbab4e9aeaa2b58a8fa2cafdf71578ea888ca2bR390-R529) [[2]](diffhunk://#diff-4b4441d6686187d5b1e82556bfbab4e9aeaa2b58a8fa2cafdf71578ea888ca2bL406-R571) [[3]](diffhunk://#diff-4b4441d6686187d5b1e82556bfbab4e9aeaa2b58a8fa2cafdf71578ea888ca2bL492-R666) [[4]](diffhunk://#diff-04b5980b8dc14454f275c66d812dced154a6990cea9b1143b186031a579c5f16R91-R92)

### UI and usability improvements

* Added line-clamp styling for notebook titles and improved wrapping for long filenames. (`src/pad/static/css/styles.css`)
* Removed the max-width restriction for the main wrapper for better layout. (`src/pad/static/css/index.css`)

### Index page enhancements

* Refactored the index page to use URL query parameters for search and sort, enabling deep linking and browser navigation. Toolbar now initializes from URL parameters. (`src/index/index.ts`) [[1]](diffhunk://#diff-299464c1bdc54c73fd004451664cc4470dacca4525d8887f5fa781004fed2f58R7-R51) [[2]](diffhunk://#diff-299464c1bdc54c73fd004451664cc4470dacca4525d8887f5fa781004fed2f58L38-R71) [[3]](diffhunk://#diff-299464c1bdc54c73fd004451664cc4470dacca4525d8887f5fa781004fed2f58R101-R112) [[4]](diffhunk://#diff-299464c1bdc54c73fd004451664cc4470dacca4525d8887f5fa781004fed2f58L89-R126) [[5]](diffhunk://#diff-299464c1bdc54c73fd004451664cc4470dacca4525d8887f5fa781004fed2f58L101-R153)

### Dependency updates

* Added `@types/node-fetch` to `package.json` for Solr client compatibility. (`package.json`)
* Updated Etherpad Docker image tag from `2` to `2.4` for improved compatibility. (`Dockerfile`)