### PR TITLE
Add Notebook-Based E2E Workflow and Update Cache Apt Action

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Install libreoffice
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
         with:
           packages: libreoffice libreoffice-pdfimport
           version: 1.0

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,85 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  notebook-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('tests/e2e/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python dependencies
+        run: |
+          set -euxo pipefail
+          pip install --upgrade pip
+          pip install -r tests/e2e/requirements.txt
+
+      - name: Install Playwright browsers
+        run: |
+          set -euxo pipefail
+          python -m playwright install --with-deps
+
+      - name: Build Docker images
+        run: |
+          set -euxo pipefail
+          docker compose build etherpad
+
+      - name: Start services
+        run: |
+          set -euxo pipefail
+          docker compose up -d
+
+      - name: Wait for services
+        run: |
+          set -euxo pipefail
+          tests/e2e/scripts/wait-for-services.sh
+
+      - name: Run notebook E2E tests
+        env:
+          E2E_TRANSITION_TIMEOUT: '30000'
+        run: |
+          set -euxo pipefail
+          python tests/e2e/run_notebooks.py
+
+      - name: Gather Docker logs
+        if: always()
+        run: |
+          set -euxo pipefail
+          mkdir -p tests/e2e/artifacts
+          docker compose logs --no-color > tests/e2e/artifacts/docker-compose.log
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results
+          path: |
+            tests/e2e/artifacts
+
+      - name: Shutdown services
+        if: always()
+        run: |
+          set -euxo pipefail
+          docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ ep_weave-*.tgz
 lib/
 static/js/
 static/css/
+
+# Python artifacts
+.python-version
+__pycache__/
+*.py[cod]
+*.pyc
+.ipynb_checkpoints/

--- a/tests/e2e/notebooks/01_Single_Pad.ipynb
+++ b/tests/e2e/notebooks/01_Single_Pad.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27c7e4cb",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "etherpad_url = \"http://localhost:9001/\"\n",
+    "test_pad_title = \"New E2E Test Pad\"\n",
+    "renamed_pad_title = \"Renamed E2E Test Pad\"\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 10000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90d24304",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57a7c4e3",
+   "metadata": {},
+   "source": [
+    "# ep_weave E2E Test - Single Pad\n",
+    "\n",
+    "- Test data to prepare: Not required"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd4710f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6553be79",
+   "metadata": {},
+   "source": [
+    "## Open etherpad_url and check if the search box is editable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35151bbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index_page = None\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await page.goto(etherpad_url)\n",
+    "\n",
+    "    await expect(page.locator(\".hashview-search-box\")).to_be_editable()\n",
+    "\n",
+    "    global index_page\n",
+    "    index_page = page\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ae824ac",
+   "metadata": {},
+   "source": [
+    "## Fill the search box with test_pad_title and click the create button."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "424ff4c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "pad_page = None\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await page.locator(\".hashview-search-box\").fill(test_pad_title)\n",
+    "    await expect(page.locator('//button[text()=\"Create\"]')).to_be_enabled()\n",
+    "\n",
+    "    # Wait for a new window to open with a title starting with test_pad_title\n",
+    "    popup_future = page.wait_for_event('popup')\n",
+    "    await page.locator('//button[text()=\"Create\"]').click()\n",
+    "    popup = await popup_future\n",
+    "    await expect(popup).to_have_title(re.compile(f\"^{test_pad_title}\"))\n",
+    "\n",
+    "    await expect(popup.locator('//iframe[@name=\"ace_outer\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    global pad_page\n",
+    "    pad_page = popup\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f04688bd",
+   "metadata": {},
+   "source": [
+    "## Edit the pad by appending \"Hello, World!\" and verify that the text appears in the pad."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80425819",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def extract_ace_inner_docbody(page):\n",
+    "    iframe_locator = page.frame_locator('iframe[name=\"ace_outer\"]').frame_locator('iframe[name=\"ace_inner\"]')\n",
+    "    await expect(iframe_locator.locator('#innerdocbody')).to_be_visible(timeout=transition_timeout)\n",
+    "    return iframe_locator.locator('#innerdocbody')\n",
+    "\n",
+    "async def _step(page):\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await expect(inner_docbody).to_be_editable(timeout=transition_timeout)\n",
+    "    inner_docbody.focus()\n",
+    "\n",
+    "    # To move the cursor to the end of line, use the End key\n",
+    "    await inner_docbody.press(\"End\")\n",
+    "    for _ in range(2):\n",
+    "        await inner_docbody.press(\"Enter\")\n",
+    "    await inner_docbody.type(\"Hello, World!\", delay=100)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42ff6b30",
+   "metadata": {},
+   "source": [
+    "## Refresh the index page and verify that the created pad is listed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd377914",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await index_page.reload()\n",
+    "    await expect(index_page.locator(f'text=\"{test_pad_title}\"')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    return index_page\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c874d63",
+   "metadata": {},
+   "source": [
+    "## Search the created pad using the search box and verify that it only shows the created pad."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e0fd665",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator(\".hashview-search-box\").fill(f'\"{test_pad_title}\"')\n",
+    "    await page.keyboard.press(\"Enter\")\n",
+    "    await expect(page.locator('.hash-link')).to_have_count(1, timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9f9d136",
+   "metadata": {},
+   "source": [
+    "## Rename the created pad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb95b29e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    page = pad_page\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await inner_docbody.focus()\n",
+    "    for _ in range(3):\n",
+    "        await inner_docbody.press(\"ArrowUp\")\n",
+    "    await inner_docbody.press(\"End\")\n",
+    "    for _ in range(len(test_pad_title) + 1):\n",
+    "        await inner_docbody.press(\"Backspace\")\n",
+    "    await inner_docbody.type(renamed_pad_title, delay=100)\n",
+    "    await inner_docbody.press(\"Enter\")\n",
+    "\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{renamed_pad_title}\"), timeout=transition_timeout)\n",
+    "    return page\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "193ce081",
+   "metadata": {},
+   "source": [
+    "## Refresh the index page and verify that the renamed pad is listed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0b1dd5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import traceback\n",
+    "\n",
+    "async def _step(page):\n",
+    "    # Reload the index page multiple times to ensure the change is reflected\n",
+    "    retries = 3\n",
+    "    for attempt in range(retries):\n",
+    "        try:\n",
+    "            await index_page.goto(etherpad_url)\n",
+    "            await expect(index_page.locator(f'text=\"{renamed_pad_title}\"')).to_be_visible(timeout=1000)\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            if attempt == retries - 1:\n",
+    "                raise\n",
+    "            print(f\"Error occurred: {e}, retrying... ({attempt + 1}/{retries})\")\n",
+    "            traceback.print_exc()\n",
+    "            await asyncio.sleep(1)  # Wait before retrying\n",
+    "\n",
+    "    return index_page\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81a1f31d",
+   "metadata": {},
+   "source": [
+    "## Search the created pad using the search box and verify that it only shows the created pad."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67f5ecb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator(\".hashview-search-box\").fill(f'\"{test_pad_title}\"')\n",
+    "    await page.keyboard.press(\"Enter\")\n",
+    "    await expect(page.locator('.hash-link')).to_have_count(0, timeout=transition_timeout)\n",
+    "    await page.locator(\".hashview-search-box\").fill(f'\"{renamed_pad_title}\"')\n",
+    "    await page.keyboard.press(\"Enter\")\n",
+    "    await expect(page.locator('.hash-link')).to_have_count(1, timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "817b589e",
+   "metadata": {},
+   "source": [
+    "Clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd03f362",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f463fd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "3.11.5",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/e2e/notebooks/02_Multiple_Pads.ipynb
+++ b/tests/e2e/notebooks/02_Multiple_Pads.ipynb
@@ -1,0 +1,423 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bf61559",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "etherpad_url = \"http://localhost:9001/\"\n",
+    "pad1_title = \"TestPad1\"\n",
+    "pad2_title = \"TestPad2\"\n",
+    "renamed_pad_title = \"TestPad3\"\n",
+    "hash_tag_original = \"#TestPad2\"\n",
+    "hash_tag_renamed = \"#TestPad3\"\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 10000\n",
+    "\n",
+    "index_page = None\n",
+    "pad1_url = None\n",
+    "pad2_url = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e0ba71f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0d56c75",
+   "metadata": {},
+   "source": [
+    "# ep_weave E2E Test - Multiple Pads\n",
+    "\n",
+    "- Test data to prepare: Not required"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e086d3d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57295c47",
+   "metadata": {},
+   "source": [
+    "## Open etherpad_url and confirm the search box is editable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "315e3267",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(etherpad_url)\n",
+    "    await expect(page.locator(\".hashview-search-box\")).to_be_editable()\n",
+    "\n",
+    "    global index_page\n",
+    "    index_page = page\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6be45be6",
+   "metadata": {},
+   "source": [
+    "## Create TestPad1 from the search box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "087bc6d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await page.locator(\".hashview-search-box\").fill(pad1_title)\n",
+    "    await expect(page.locator('//button[text()=\"Create\"]')).to_be_enabled()\n",
+    "\n",
+    "    popup_future = page.wait_for_event('popup')\n",
+    "    await page.locator('//button[text()=\"Create\"]').click()\n",
+    "    popup = await popup_future\n",
+    "    await expect(popup).to_have_title(re.compile(f\"^{pad1_title}\"))\n",
+    "    await expect(popup.locator('//iframe[@name=\"ace_outer\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    global pad1_url\n",
+    "    pad1_url = popup.url\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e04d698c",
+   "metadata": {},
+   "source": [
+    "## Append the hash tag to TestPad1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eee88905",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def extract_ace_inner_docbody(page):\n",
+    "    iframe_locator = page.frame_locator('iframe[name=\"ace_outer\"]').frame_locator('iframe[name=\"ace_inner\"]')\n",
+    "    await expect(iframe_locator.locator('#innerdocbody')).to_be_visible(timeout=transition_timeout)\n",
+    "    return iframe_locator.locator('#innerdocbody')\n",
+    "\n",
+    "async def _step(page):\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await expect(inner_docbody).to_be_editable(timeout=transition_timeout)\n",
+    "    await inner_docbody.focus()\n",
+    "    await inner_docbody.press(\"End\")\n",
+    "    for _ in range(2):\n",
+    "        await inner_docbody.press(\"Enter\")\n",
+    "    await inner_docbody.type(hash_tag_original, delay=100)\n",
+    "    await expect(inner_docbody).to_contain_text(hash_tag_original, timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64c8ba9a",
+   "metadata": {},
+   "source": [
+    "## Verify the rollup shows the create link for TestPad2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8979dca5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    hash_create_link = page.locator('.hash-link.hash-create .hash-title a')\n",
+    "    await expect(hash_create_link).to_have_text(pad2_title, timeout=transition_timeout)\n",
+    "    await hash_create_link.scroll_into_view_if_needed()\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcb8cd19",
+   "metadata": {},
+   "source": [
+    "## Open TestPad2 from the rollup create link."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c93e838",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    hash_create_link = page.locator('.hash-link.hash-create .hash-title a')\n",
+    "    await hash_create_link.click()\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{pad2_title}\"))\n",
+    "\n",
+    "    hash_link = page.locator('.hash-link:not(.hash-create) .hash-title a')\n",
+    "    await expect(hash_link).to_have_text(pad1_title, timeout=transition_timeout)\n",
+    "    await hash_link.scroll_into_view_if_needed()\n",
+    "\n",
+    "    global pad2_url\n",
+    "    pad2_url = page.url\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53706727",
+   "metadata": {},
+   "source": [
+    "## Reload TestPad1 and ensure TestPad2 appears in the rollup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78b711d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(pad1_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{pad1_title}\"))\n",
+    "\n",
+    "    hash_link = page.locator('.hash-link:not(.hash-create) .hash-title a')\n",
+    "    await expect(hash_link).to_have_text(pad2_title, timeout=transition_timeout)\n",
+    "    await hash_link.scroll_into_view_if_needed()\n",
+    "\n",
+    "    await page.goto(pad2_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{pad2_title}\"))\n",
+    "\n",
+    "    hash_link = page.locator('.hash-link:not(.hash-create) .hash-title a')\n",
+    "    await expect(hash_link).to_have_text(pad1_title, timeout=transition_timeout)\n",
+    "    await hash_link.scroll_into_view_if_needed()\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "336a9091",
+   "metadata": {},
+   "source": [
+    "## Rename TestPad2 to TestPad3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7273ff11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def _step(page):\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await inner_docbody.focus()\n",
+    "    for _ in range(3):\n",
+    "        await inner_docbody.press(\"ArrowUp\")\n",
+    "    await inner_docbody.press(\"End\")\n",
+    "    for _ in range(len(pad2_title) + 1):\n",
+    "        await inner_docbody.press(\"Backspace\")\n",
+    "    await inner_docbody.type(renamed_pad_title, delay=100)\n",
+    "    await inner_docbody.press(\"Enter\")\n",
+    "\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await asyncio.sleep(1)  # Wait a moment to ensure the title change is processed\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{renamed_pad_title}\"), timeout=transition_timeout)\n",
+    "\n",
+    "    # Wait for the change title button to appear to ensure the title change is processed\n",
+    "    change_title_button = page.locator('.hashview-change-title')\n",
+    "    await expect(change_title_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(change_title_button).to_have_text(f'Title changed: {renamed_pad_title} from {pad2_title}', timeout=transition_timeout)\n",
+    "\n",
+    "    # No links for renamed pad - ensure no old links are present\n",
+    "    old_hash_link = page.locator(f'.hash-link:not(.hash-create) .hash-title:has-text(\"{pad1_title}\")')\n",
+    "    await expect(old_hash_link).to_have_count(0, timeout=transition_timeout)\n",
+    "\n",
+    "    global pad2_url\n",
+    "    pad2_url = page.url\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "549c5d7a",
+   "metadata": {},
+   "source": [
+    "## Click the change title banner to update the hash link."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "801a2380",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import traceback\n",
+    "\n",
+    "async def _step(page):\n",
+    "    change_title_button = page.locator('.hashview-change-title')\n",
+    "    await expect(change_title_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(change_title_button).to_contain_text(\n",
+    "        f'Title changed: {renamed_pad_title} from {pad2_title}', timeout=transition_timeout\n",
+    "    )\n",
+    "    await change_title_button.click()\n",
+    "\n",
+    "    await expect(change_title_button).not_to_be_visible(timeout=transition_timeout)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "\n",
+    "    # Retry until the link reappears\n",
+    "    for _ in range(5):\n",
+    "        try:\n",
+    "            await page.reload()\n",
+    "            hash_link = page.locator('.hash-link:not(.hash-create) .hash-title a')\n",
+    "            await expect(hash_link).to_have_text(pad1_title, timeout=transition_timeout)\n",
+    "            await hash_link.scroll_into_view_if_needed()\n",
+    "            break\n",
+    "        except:\n",
+    "            if _ == 4:\n",
+    "                raise\n",
+    "            print(f\"Retrying after failure... ({_ + 1}/5)\")\n",
+    "            traceback.print_exc()\n",
+    "            await asyncio.sleep(2)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34661d55",
+   "metadata": {},
+   "source": [
+    "## Confirm the hash in TestPad1 updates to #TestPad3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72263cd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(pad1_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{pad1_title}\"))\n",
+    "\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await expect(inner_docbody).to_contain_text(hash_tag_renamed, timeout=transition_timeout)\n",
+    "    await expect(inner_docbody).not_to_contain_text(hash_tag_original)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b70e6ca",
+   "metadata": {},
+   "source": [
+    "Clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4961e01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cafe2917",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "3.11.5",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/e2e/notebooks/03_Hierarchical_Pads.ipynb
+++ b/tests/e2e/notebooks/03_Hierarchical_Pads.ipynb
@@ -1,0 +1,509 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96cd08bb",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "etherpad_url = \"http://localhost:9001/\"\n",
+    "root_pad_title = \"HierarchyRoot\"\n",
+    "root_pad_renamed_title = \"HierarchyRootRenamed\"\n",
+    "child_pad_title = \"HierarchyRoot/SubPad\"\n",
+    "child_pad_renamed_title = \"HierarchyRootRenamed/SubPad\"\n",
+    "additional_child_pad_title = \"HierarchyRootRenamed/SubPad2\"\n",
+    "hash_tag_child = f\"#{child_pad_title}\"\n",
+    "hash_tag_child_renamed = f\"#{child_pad_renamed_title}\"\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 10000\n",
+    "\n",
+    "index_page = None\n",
+    "root_pad_url = None\n",
+    "child_pad_url = None\n",
+    "additional_child_pad_url = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04032b79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3f71eb6",
+   "metadata": {},
+   "source": [
+    "# ep_weave E2E Test - Hierarchical Pads\n",
+    "\n",
+    "- Test data to prepare: Not required"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8db260b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2c71b63",
+   "metadata": {},
+   "source": [
+    "## Open etherpad_url and confirm the search box is editable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63d3e812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(etherpad_url)\n",
+    "    await expect(page.locator(\".hashview-search-box\")).to_be_editable()\n",
+    "\n",
+    "    global index_page\n",
+    "    index_page = page\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9d46b65",
+   "metadata": {},
+   "source": [
+    "## Create HierarchyRoot from the search box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6487c63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await page.locator(\".hashview-search-box\").fill(root_pad_title)\n",
+    "    await expect(page.locator('//button[text()=\"Create\"]')).to_be_enabled()\n",
+    "\n",
+    "    popup_future = page.wait_for_event('popup')\n",
+    "    await page.locator('//button[text()=\"Create\"]').click()\n",
+    "    popup = await popup_future\n",
+    "    await expect(popup).to_have_title(re.compile(f\"^{root_pad_title}\"))\n",
+    "    await expect(popup.locator('//iframe[@name=\"ace_outer\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    global root_pad_url\n",
+    "    root_pad_url = popup.url\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "782af6ee",
+   "metadata": {},
+   "source": [
+    "## Append the hierarchical hash tag to HierarchyRoot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4a76753",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def extract_ace_inner_docbody(page):\n",
+    "    iframe_locator = page.frame_locator('iframe[name=\"ace_outer\"]').frame_locator('iframe[name=\"ace_inner\"]')\n",
+    "    await expect(iframe_locator.locator('#innerdocbody')).to_be_visible(timeout=transition_timeout)\n",
+    "    return iframe_locator.locator('#innerdocbody')\n",
+    "\n",
+    "async def _step(page):\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await expect(inner_docbody).to_be_editable(timeout=transition_timeout)\n",
+    "    await inner_docbody.focus()\n",
+    "    await inner_docbody.press('End')\n",
+    "    for _ in range(2):\n",
+    "        await inner_docbody.press('Enter')\n",
+    "    await inner_docbody.type(hash_tag_child, delay=100)\n",
+    "    await expect(inner_docbody).to_contain_text(hash_tag_child, timeout=transition_timeout)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await asyncio.sleep(1)  # wait for the flush to the server\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05eb0813",
+   "metadata": {},
+   "source": [
+    "## Verify the rollup shows the create link for the nested pad."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f9610e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    hash_create_link = page.locator('.hash-link.hash-create .hash-title a')\n",
+    "    await expect(hash_create_link).to_have_text(child_pad_title, timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f05c6bf8",
+   "metadata": {},
+   "source": [
+    "## Open HierarchyRoot/SubPad from the rollup create link."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b6ed290",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    hash_create_link = page.locator('.hash-link.hash-create .hash-title a')\n",
+    "    await hash_create_link.click()\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{child_pad_title}\"))\n",
+    "\n",
+    "    global child_pad_url\n",
+    "    child_pad_url = page.url\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f353a886",
+   "metadata": {},
+   "source": [
+    "## Reload HierarchyRoot and ensure the nested pad appears in the rollup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9eed3836",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(root_pad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{root_pad_title}\"))\n",
+    "\n",
+    "    hash_link = page.locator('.hash-link:not(.hash-create) .hash-title a', has_text=child_pad_title)\n",
+    "    await expect(hash_link).to_have_count(2, timeout=transition_timeout)\n",
+    "\n",
+    "    await page.goto(child_pad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{child_pad_title}\"))\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17f62c7b",
+   "metadata": {},
+   "source": [
+    "## Open HierarychyRoot from the breadcrumbs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a53bea51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    parent_link = page.locator(f'//a[contains(@class, \"hashview-path-segment\") and text()=\"{root_pad_title}\"]')\n",
+    "    await expect(parent_link).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    await parent_link.click()\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4b2c343",
+   "metadata": {},
+   "source": [
+    "## Rename HierarchyRoot to HierarchyRootRenamed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa61f18f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):    \n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await inner_docbody.focus()\n",
+    "    for _ in range(3):\n",
+    "        await inner_docbody.press('ArrowUp')\n",
+    "    await inner_docbody.press('End')\n",
+    "    for _ in range(len(root_pad_title) + 1):\n",
+    "        await inner_docbody.press('Backspace', delay=100)\n",
+    "    await inner_docbody.type(root_pad_renamed_title, delay=100)\n",
+    "    await inner_docbody.press('Enter')\n",
+    "\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{root_pad_renamed_title}\"), timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f09e9a60",
+   "metadata": {},
+   "source": [
+    "## Apply the change-title banner to update hashes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f62702f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def _step(page):\n",
+    "    change_title_button = page.locator('.hashview-change-title')\n",
+    "    await expect(change_title_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(change_title_button).to_contain_text(\n",
+    "        f'Title changed: {root_pad_renamed_title} from {root_pad_title}', timeout=transition_timeout\n",
+    "    )\n",
+    "    await change_title_button.click()\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await asyncio.sleep(1)  # wait for the flush to the server\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb24ae8b",
+   "metadata": {},
+   "source": [
+    "## Confirm HierarchyRoot now contains #HierarchyRootRenamed/SubPad."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21980bff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(root_pad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{root_pad_renamed_title}\"))\n",
+    "\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await expect(inner_docbody).to_contain_text(hash_tag_child_renamed, timeout=transition_timeout)\n",
+    "    await expect(inner_docbody).not_to_contain_text(hash_tag_child)\n",
+    "\n",
+    "    hash_link = page.locator('.hash-link .hash-title a', has_text=child_pad_renamed_title)\n",
+    "    await expect(hash_link).to_have_count(2, timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2761b52a",
+   "metadata": {},
+   "source": [
+    "## Verify the child pad reflects the renamed hierarchy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fb02721",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(child_pad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{child_pad_renamed_title}\"))\n",
+    "\n",
+    "    inner_docbody = await extract_ace_inner_docbody(page)\n",
+    "    await expect(inner_docbody).to_contain_text(child_pad_renamed_title, timeout=transition_timeout)\n",
+    "    await expect(inner_docbody).not_to_contain_text(child_pad_title)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "133ceb8f",
+   "metadata": {},
+   "source": [
+    "## Create HierarchyRootRenamed/SubPad2 from the index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53ccdd47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(etherpad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page.locator('.hashview-search-box')).to_be_editable()\n",
+    "\n",
+    "    await page.locator('.hashview-search-box').fill(additional_child_pad_title)\n",
+    "    await expect(page.locator('//button[text()=\"Create\"]')).to_be_enabled()\n",
+    "\n",
+    "    popup_future = page.wait_for_event('popup')\n",
+    "    await page.locator('//button[text()=\"Create\"]').click()\n",
+    "    popup = await popup_future\n",
+    "    await popup.wait_for_load_state('networkidle')\n",
+    "    await expect(popup).to_have_title(re.compile(f\"^{additional_child_pad_title}\"))\n",
+    "\n",
+    "    global additional_child_pad_url\n",
+    "    additional_child_pad_url = popup.url\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e08c473",
+   "metadata": {},
+   "source": [
+    "## Ensure HierarchyRootRenamed lists both child pads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d5c1c38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(root_pad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{root_pad_renamed_title}\"))\n",
+    "\n",
+    "    # Child pages: 2 pages(SubPad and SubPad2) + Hash Link: 1 page(SubPad renamed)\n",
+    "    await expect(page.locator('.hash-link .hash-title a', has_text=child_pad_renamed_title)).to_have_count(3, timeout=transition_timeout)\n",
+    "    await expect(page.locator('.hash-link .hash-title a', has_text=additional_child_pad_title)).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    await page.goto(additional_child_pad_url)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await expect(page).to_have_title(re.compile(f\"^{additional_child_pad_title}\"))\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67efe4b9",
+   "metadata": {},
+   "source": [
+    "Clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15506d2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "449aff97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "3.11.5",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/e2e/notebooks/scripts/__init__.py
+++ b/tests/e2e/notebooks/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""E2E helper scripts package."""

--- a/tests/e2e/notebooks/scripts/playwright.py
+++ b/tests/e2e/notebooks/scripts/playwright.py
@@ -1,0 +1,233 @@
+"""Playwright utility helpers.
+
+Copied from https://github.com/RCOSDP/RDM-e2e-test-nb (scripts/playwright.py)
+commit dda7a5de4336c3c3a79537f1537de7d65a0034e6 with minimal path adjustments
+for ep_weave.
+"""
+
+from datetime import datetime
+import os
+import shutil
+import sys
+import tempfile
+import time
+import traceback
+
+from IPython.display import Image
+from playwright.async_api import async_playwright, expect
+
+playwright = None
+current_session_id = None
+current_browser = None
+current_contexts = None
+default_last_path = None
+context_close_on_fail = True
+temp_dir = None
+
+
+async def run_pw(
+    f,
+    last_path=default_last_path,
+    screenshot=True,
+    permissions=None,
+    new_context=False,
+    new_page=False,
+):
+    global current_browser
+    if current_browser is None:
+        current_browser = await playwright.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage", "--lang=ja"],
+        )
+
+    global current_contexts
+    if current_contexts is None or len(current_contexts) == 0 or new_context:
+        videos_dir = os.path.join(temp_dir, "videos/")
+        os.makedirs(videos_dir, exist_ok=True)
+        har_path = os.path.join(temp_dir, "har.zip")
+
+        context = await current_browser.new_context(
+            locale="ja-JP",
+            record_video_dir=videos_dir,
+            record_har_path=har_path,
+        )
+        if current_contexts is None:
+            current_contexts = [(context, [])]
+        else:
+            current_contexts.append((context, []))
+
+    current_context, current_pages = current_contexts[-1]
+    if len(current_pages) == 0 or new_page:
+        current_pages.append(await current_context.new_page())
+
+    current_time = time.time()
+    print(f"Start epoch: {current_time} seconds")
+    if permissions is not None:
+        await current_context.grant_permissions(permissions)
+    next_page = None
+    if f is not None:
+        try:
+            next_page = await f(current_pages[-1])
+        except Exception:
+            if context_close_on_fail:
+                await finish_pw_context(screenshot=screenshot, last_path=last_path)
+                raise
+            if screenshot:
+                await _save_screenshot()
+            raise
+    if next_page is not None:
+        current_pages.append(next_page)
+    screenshot_path = os.path.join(temp_dir, "screenshot.png")
+    await current_pages[-1].screenshot(path=screenshot_path)
+    return Image(screenshot_path)
+
+
+async def close_latest_page(last_path=None):
+    global current_contexts
+    if current_contexts is None or len(current_contexts) == 0:
+        raise Exception("No contexts")
+    current_context, current_pages = current_contexts[-1]
+    if len(current_contexts) <= 1 and len(current_pages) <= 1:
+        raise Exception(
+            "It is only possible to close when two or more contexts or pages are stacked"
+        )
+    os.makedirs(last_path or default_last_path, exist_ok=True)
+    last_page = current_pages[-1]
+    if last_page in current_pages[:-1] or any(
+        last_page in pages for _, pages in current_contexts[:-1]
+    ):
+        assert len(current_pages) > 0, current_pages
+        current_contexts[-1] = (current_context, current_pages[:-1])
+        return
+    video_path = await last_page.video.path()
+    index = len(current_pages)
+    dest_video_path = os.path.join(last_path or default_last_path, f"video-{index}.webm")
+    shutil.copyfile(video_path, dest_video_path)
+    current_pages = current_pages[:-1]
+    current_contexts[-1] = (current_context, current_pages)
+    await last_page.close()
+    if len(current_pages) > 0:
+        return
+    current_contexts = current_contexts[:-1]
+    await current_context.close()
+
+
+async def init_pw_context(close_on_fail=True, last_path=None):
+    global playwright
+    global current_session_id
+    global default_last_path
+    global current_browser
+    global temp_dir
+    global context_close_on_fail
+    global current_contexts
+    if current_browser is not None:
+        await current_browser.close()
+        current_browser = None
+    if playwright is not None:
+        await playwright.stop()
+        playwright = None
+    playwright = await async_playwright().start()
+    current_session_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+    default_last_path = last_path or os.path.join(
+        os.path.expanduser("~/last-screenshots"), current_session_id
+    )
+    temp_dir = tempfile.mkdtemp()
+    context_close_on_fail = close_on_fail
+    if current_contexts is not None:
+        for current_context in current_contexts:
+            await current_context.close()
+    current_contexts = None
+    return (current_session_id, temp_dir)
+
+
+async def finish_pw_context(screenshot=False, last_path=None):
+    global current_browser
+    await _finish_pw_context(screenshot=screenshot, last_path=last_path)
+    if current_browser is not None:
+        await current_browser.close()
+        current_browser = None
+
+
+async def save_screenshot(path):
+    if current_contexts is None or len(current_contexts) == 0:
+        raise Exception("No contexts")
+    _, current_pages = current_contexts[-1]
+    if current_pages is None or len(current_pages) == 0:
+        raise Exception("Unexpected state")
+    await current_pages[-1].screenshot(path=path)
+    return path
+
+
+async def _save_screenshot(last_path=None):
+    if current_contexts is None or len(current_contexts) == 0:
+        raise Exception("No contexts")
+    _, current_pages = current_contexts[-1]
+    os.makedirs(last_path or default_last_path, exist_ok=True)
+    if current_pages is None or len(current_pages) == 0:
+        return
+    screenshot_path = os.path.join(temp_dir, "last-screenshot.png")
+    await current_pages[-1].screenshot(path=screenshot_path)
+    dest_screenshot_path = os.path.join(
+        last_path or default_last_path, "last-screenshot.png"
+    )
+    shutil.copyfile(screenshot_path, dest_screenshot_path)
+    print(f"Screenshot: {dest_screenshot_path}")
+
+
+async def _finish_pw_context(screenshot=False, last_path=None):
+    global current_contexts
+    if current_contexts is None or len(current_contexts) == 0:
+        return
+    current_context, current_pages = current_contexts[-1]
+    os.makedirs(last_path or default_last_path, exist_ok=True)
+    timeout_on_screenshot = False
+    if screenshot and current_pages is not None and len(current_pages) > 0:
+        try:
+            await _save_screenshot(last_path=last_path)
+        except Exception:
+            print("スクリーンショットの取得に失敗しました。", file=sys.stderr)
+            traceback.print_exc()
+            timeout_on_screenshot = True
+    if timeout_on_screenshot:
+        return
+    current_contexts = current_contexts[::-1]
+    await current_context.close()
+    for i, current_page in enumerate(current_pages):
+        index = i + 1
+        try:
+            video_path = await current_page.video.path()
+            dest_video_path = os.path.join(
+                last_path or default_last_path, f"video-{index}.webm"
+            )
+            shutil.copyfile(video_path, dest_video_path)
+            print(f"Video: {dest_video_path}")
+        except Exception:
+            print("スクリーンキャプチャ動画の取得に失敗しました。", file=sys.stderr)
+            traceback.print_exc()
+            timeout_on_screenshot = True
+    if timeout_on_screenshot:
+        return
+    har_path = os.path.join(temp_dir, "har.zip")
+    dest_har_path = os.path.join(last_path or default_last_path, "har.zip")
+    if os.path.exists(har_path):
+        shutil.copyfile(har_path, dest_har_path)
+        print(f"HAR: {dest_har_path}")
+    else:
+        print(".harファイルの取得に失敗しました。", file=sys.stderr)
+    shutil.rmtree(temp_dir)
+    for page in current_pages:
+        await page.close()
+    if len(current_contexts) == 0:
+        return
+    await _finish_pw_context(screenshot=False, last_path=last_path)
+
+
+__all__ = [
+    "async_playwright",
+    "expect",
+    "run_pw",
+    "close_latest_page",
+    "init_pw_context",
+    "finish_pw_context",
+    "save_screenshot",
+]

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,3 @@
+papermill>=2.5.0
+notebook>=7.0.0
+playwright>=1.45.0

--- a/tests/e2e/run_notebooks.py
+++ b/tests/e2e/run_notebooks.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Execute notebook-based E2E scenarios with Papermill."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import argparse
+import os
+
+import papermill as pm
+from papermill.exceptions import PapermillExecutionError
+
+NOTEBOOK_ROOT = Path(__file__).resolve().parent / "notebooks"
+ARTIFACT_ROOT = Path(__file__).resolve().parent / "artifacts"
+RESULT_ROOT = ARTIFACT_ROOT / "notebooks"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Execute notebook E2E tests.")
+    parser.add_argument(
+        "--skip-failed-test",
+        dest="skip_failed_test",
+        action="store_true",
+        help="Continue executing remaining notebooks even if a notebook fails.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not NOTEBOOK_ROOT.exists():
+        raise FileNotFoundError(f"Notebook directory not found: {NOTEBOOK_ROOT}")
+
+    notebooks = sorted(NOTEBOOK_ROOT.glob("*.ipynb"))
+
+    transition_timeout_env = os.getenv("E2E_TRANSITION_TIMEOUT")
+    if transition_timeout_env:
+        try:
+            transition_timeout = int(transition_timeout_env)
+        except ValueError as exc:
+            raise ValueError("E2E_TRANSITION_TIMEOUT must be an integer") from exc
+    else:
+        transition_timeout = None
+
+    ARTIFACT_ROOT.mkdir(parents=True, exist_ok=True)
+    RESULT_ROOT.mkdir(parents=True, exist_ok=True)
+
+    if not notebooks:
+        print("No notebooks to execute. Add notebooks under tests/e2e/notebooks.")
+        return 0
+
+    failures: list[Path] = []
+
+    for notebook in notebooks:
+        result_notebook = RESULT_ROOT / f"{notebook.stem}-result.ipynb"
+        notebook_dir = notebook.parent
+        notebook_artifact_dir = RESULT_ROOT / notebook.stem
+        notebook_artifact_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Running notebook: {notebook} -> {result_notebook}")
+        parameters = {"default_result_path": str(notebook_artifact_dir)}
+        if transition_timeout is not None:
+            parameters["transition_timeout"] = transition_timeout
+        try:
+            pm.execute_notebook(
+                str(notebook),
+                str(result_notebook),
+                parameters=parameters,
+                cwd=str(notebook_dir),
+            )
+        except PapermillExecutionError as err:
+            failures.append(notebook)
+            if not args.skip_failed_test:
+                raise
+            print(f"Notebook failed but continuing: {notebook} (reason: {err})")
+
+    if failures:
+        print("Failed notebooks:")
+        for failed in failures:
+            print(f"  - {failed}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/scripts/wait-for-services.sh
+++ b/tests/e2e/scripts/wait-for-services.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+ETHERPAD_URL="${ETHERPAD_URL:-http://localhost:9001/health}"
+MAX_RETRIES=60
+SLEEP_SECONDS=5
+
+for attempt in $(seq 1 "${MAX_RETRIES}"); do
+  if curl -vvv --fail --show-error "${ETHERPAD_URL}"; then
+    echo "Etherpad is accepting connections at ${ETHERPAD_URL}"
+    exit 0
+  fi
+  echo "Waiting for Etherpad... attempt ${attempt}/${MAX_RETRIES}" >&2
+  sleep "${SLEEP_SECONDS}"
+done
+
+docker compose ps >&2 || true
+>&2 echo "Timed out waiting for Etherpad at ${ETHERPAD_URL}"
+exit 1


### PR DESCRIPTION
## Summary
- add a Papermill + Playwright GitHub Actions workflow so our notebook-based E2E scenarios run in CI while preserving their step-by-step diagnostics and reuse between manual and automated testing
- bump `awalsh128/cache-apt-pkgs-action` to v1.5.3 because the previous release is no longer supported

## Details
- to bring notebook E2E coverage into CI without losing their debugging ergonomics, introduce `.github/workflows/e2e-tests.yml`, provisioning Python 3.11, Playwright browsers, and the dockerized Etherpad stack before executing notebooks and archiving results
- to run notebooks deterministically, implement `tests/e2e/run_notebooks.py` with Papermill, discovery of E2E notebooks, optional `--skip-failed-test`, and support for the `E2E_TRANSITION_TIMEOUT` environment variable
- to keep browser sessions manageable from notebooks, add Playwright helpers under `tests/e2e/notebooks/scripts/playwright.py` along with the notebooks, requirements, and wait script those flows depend on
- to reduce noise in the repository and align automation, extend `.gitignore` for Python/Jupyter artifacts and update `.github/workflows/backend-tests.yml` to reference `awalsh128/cache-apt-pkgs-action@v1.5.3`
