### PR TITLE
Support for Etherpad 2.5+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ETHERPAD_IMAGE_NAME="etherpad/etherpad"
-ARG ETHERPAD_IMAGE_TAG="2.4"
+ARG ETHERPAD_IMAGE_TAG="2"
 
 FROM mcr.microsoft.com/devcontainers/typescript-node:18 AS build-stage
 

--- a/ep.json
+++ b/ep.json
@@ -3,6 +3,7 @@
     {
       "name": "ep_weave",
       "hooks": {
+        "loadSettings": "ep_weave/lib/index",
         "expressCreateServer" : "ep_weave/lib/index:registerRoute",
         "preAuthorize": "ep_weave/lib/index",
         "clientVars": "ep_weave/lib/index",

--- a/src/pad/index.ts
+++ b/src/pad/index.ts
@@ -12,13 +12,14 @@ import { escapeForText } from "./static/js/result";
 const absolutePaths = require("ep_etherpad-lite/node/utils/AbsolutePaths");
 const argv = require("ep_etherpad-lite/node/utils/Cli").argv;
 const { v4: uuidv4 } = require("uuid");
-const settings = require("ep_etherpad-lite/node/utils/Settings");
 const api = require("ep_etherpad-lite/node/db/API");
 const authorManager = require("ep_etherpad-lite/node/db/AuthorManager");
 const db = require("ep_etherpad-lite/node/db/DB").db;
 const importEtherpad = require("ep_etherpad-lite/node/utils/ImportEtherpad");
 
 let apikey: string | null = null;
+let epWeaveSettings: PluginSettings | undefined;
+let epSearchSettings: any;
 
 type PluginSettings = {
   basePath?: string;
@@ -79,12 +80,19 @@ async function getAuthorForUser(user: any) {
   return await authorManager.getAuthorId(token, user);
 }
 
+exports.loadSettings = (hookName: string, context: { settings: any }) => {
+  epWeaveSettings = (context.settings.ep_weave || {}) as PluginSettings;
+  epSearchSettings = context.settings.ep_search || {};
+};
+
 exports.clientVars = (
   hookName: string,
   context: any,
   callback: (data: any) => void
 ) => {
-  const epWeaveSettings = (settings.ep_weave || {}) as PluginSettings;
+  if (!epWeaveSettings) {
+    throw new Error("ep_weave settings not loaded. loadSettings hook must be called first.");
+  }
   return callback({
     ep_weave: {
       toggleRollupKey: epWeaveSettings.toggleRollupKey || "ctrl+shift+r",
@@ -123,10 +131,12 @@ exports.registerRoute = (
   args: ExpressCreateServerArgs,
   cb: (next: any) => void
 ) => {
-  const epWeavePluginSettings = (settings.ep_weave || {}) as PluginSettings;
-  initializePads(epWeavePluginSettings)
+  if (!epWeaveSettings || !epSearchSettings) {
+    throw new Error("ep_weave/ep_search settings not loaded. loadSettings hook must be called first.");
+  }
+  initializePads(epWeaveSettings)
     .then(() => {
-      performRegisterRoute(epWeavePluginSettings, hookName, args, cb);
+      performRegisterRoute(epWeaveSettings!, epSearchSettings!, hookName, args, cb);
     })
     .catch((err) => {
       console.error(
@@ -177,13 +187,13 @@ async function initializePads(epWeavePluginSettings: PluginSettings) {
 
 function performRegisterRoute(
   epWeavePluginSettings: PluginSettings,
+  epSearchPluginSettings: any,
   hookName: any,
   args: ExpressCreateServerArgs,
   cb: (next: any) => void
 ) {
   const basePath = epWeavePluginSettings.basePath || "";
-  const pluginSettings = settings.ep_search || {};
-  const searchEngine = createSearchEngine(pluginSettings);
+  const searchEngine = createSearchEngine(epSearchPluginSettings);
   const apikeyFilename = absolutePaths.makeAbsolute(
     argv.apikey || "./APIKEY.txt"
   );

--- a/static/tests/backend/specs/title.ts
+++ b/static/tests/backend/specs/title.ts
@@ -51,6 +51,7 @@ describe("access via title", function () {
   it("can access via title", async function () {
     const html1 = () => buildHTML("<p>TESTPAD</p><p>Hello New Pad #PAD2</p>");
     await createPad(padID1);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     await setHTML(padID1, html1());
     await agent
       .get(getHTMLEndPointFor(padID1))
@@ -64,6 +65,7 @@ describe("access via title", function () {
       .expect("Location", `/p/${padID1}`);
     const html2 = () => buildHTML("<p>PAD2</p><p>2nd Pad</p>");
     await createPad(padID2);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     await setHTML(padID2, html2());
     await agent
       .get(getHTMLEndPointFor(padID2))


### PR DESCRIPTION
This pull request upgrades ep_weave to support Etherpad 2.5 and later versions.

### Changes

* Migrated from direct `Settings` module imports to the `loadSettings` hook pattern, following the same approach as ep_search (see https://github.com/NII-cloud-operation/ep_search/commit/ff7d071f97c341e80d972844a79cd8a8af479f5c)
* Updated Dockerfile to use Etherpad image tag `"2"` instead of `"2.4"`, allowing compatibility with the latest 2.x versions
* Added 1-second delay between pad creation and content setting to resolve search timing issues in backend tests


Etherpad 2.5+ no longer allows plugins to directly require the Settings module, so the loadSettings hook must be used instead.