### PR TITLE
Support for Etherpad 3

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,29 +18,30 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Install libreoffice
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libreoffice libreoffice-pdfimport
           version: 1.0
       -
         name: Install etherpad core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
           path: etherpad-lite
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
+        name: Install Node.js
         with:
-          node-version: '24'
-      - uses: pnpm/action-setup@v3
+          node-version: 24
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -49,20 +50,9 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       -
         name: Checkout plugin repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: plugin
-      -
-        name: Determine plugin name
-        id: plugin_name
-        working-directory: ./plugin
-        run: |
-          npx -c 'printf %s\\n "::set-output name=plugin_name::${npm_package_name}"'
-      -
-        name: Link plugin directory
-        working-directory: ./plugin
-        run: |
-          pnpm link --global
       - name: Remove tests
         working-directory: ./etherpad-lite
         run: rm -rf ./src/tests/backend/specs
@@ -73,42 +63,28 @@ jobs:
       - name: Build plugin
         working-directory: ./plugin
         run: |
-          pnpm i
+          pnpm i --no-frozen-lockfile
           pnpm run build
-          ls -la .
       - name: Build Solr
         working-directory: ./plugin
         run: |
           docker buildx build -o type=docker -t ep_weave/solr -f ./solr/Dockerfile .
-      - name: Link plugin to etherpad-lite
+      - name: Install plugin
         working-directory: ./etherpad-lite
         run: |
-          pnpm link --global $PLUGIN_NAME
-          pnpm run plugins i --path  ../../plugin
-        env:
-          PLUGIN_NAME: ${{ steps.plugin_name.outputs.plugin_name }}
+          pnpm run plugins i --path ../../plugin
       - name: Prepare ep_search
         working-directory: ./etherpad-lite
         run: |
           git clone -b feature/search-engine https://github.com/NII-cloud-operation/ep_search.git /tmp/ep_search
-          cd /tmp/ep_search
           ls -la /tmp/ep_search
-          npm pack
       - name: Install ep_search
         working-directory: ./etherpad-lite
         run: |
           pnpm run plugins i --path /tmp/ep_search
-      - name: Link ep_etherpad-lite
-        working-directory: ./etherpad-lite/src
-        run: |
-          pnpm link --global
-      - name: Link etherpad to plugin
-        working-directory: ./plugin
-        run: |
-          pnpm link --global ep_etherpad-lite
       -
         name: Run the backend tests
-        working-directory: ./etherpad-lite
+        working-directory: ./etherpad-lite/src
         run: |
           docker run -d --name etherpad-solr -p 8983:8983 ep_weave/solr
           MAX_ATTEMPTS=60
@@ -132,7 +108,13 @@ jobs:
             fi
             sleep 0.5
           done
-          pnpm run test --settings ../plugin/tests/settings.json
+          shopt -s globstar
+          res=$(find ./plugin_packages -path "*/static/tests/backend/specs/*" 2>/dev/null | wc -l)
+          if [ $res -eq 0 ]; then
+            echo "No backend tests found"
+          else
+            npx cross-env NODE_ENV=production mocha --import=tsx --timeout 120000 --recursive plugin_packages/ep_*/static/tests/backend/specs/** --settings ../plugin/tests/settings.json
+          fi
         env:
           LOGLEVEL: DEBUG
       - name: Stop Solr

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -28,10 +28,13 @@ jobs:
         with:
           repository: ether/etherpad-lite
           path: etherpad-lite
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: pnpm/action-setup@v3
         name: Install pnpm
         with:
-          version: 8
+          version: 10
           run_install: false
       - name: Get pnpm store directory
         shell: bash
@@ -70,8 +73,8 @@ jobs:
       - name: Build plugin
         working-directory: ./plugin
         run: |
-          npm i --include dev
-          npm run build
+          pnpm i
+          pnpm run build
           ls -la .
       - name: Build Solr
         working-directory: ./plugin

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -12,22 +12,24 @@ jobs:
     steps:
       -
         name: Check out Etherpad core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
-      - uses: actions/setup-node@v4
+          path: etherpad-lite
+      - uses: actions/setup-node@v6
+        name: Install Node.js
         with:
-          node-version: '24'
-      - uses: pnpm/action-setup@v3
+          node-version: 24
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -35,63 +37,56 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       -
-        name: Check out the plugin
-        uses: actions/checkout@v3
+        name: Checkout plugin repository
+        uses: actions/checkout@v6
         with:
-          path: ./node_modules/__tmp
-      -
-        name: export GIT_HASH to env
-        id: environment
+          path: plugin
+      - name: Build plugin
+        working-directory: ./plugin
         run: |
-          cd ./node_modules/__tmp
-          echo "::set-output name=sha_short::$(git rev-parse --short ${{ github.sha }})"
-      -
-        name: Determine plugin name
-        id: plugin_name
-        run: |
-          cd ./node_modules/__tmp
-          npx -c 'printf %s\\n "::set-output name=plugin_name::${npm_package_name}"'
-      -
-        name: Rename plugin directory
-        env:
-          PLUGIN_NAME: ${{ steps.plugin_name.outputs.plugin_name }}
-        run: |
-          mv ./node_modules/__tmp ./node_modules/"${PLUGIN_NAME}"
-      -
-        name: Install plugin dependencies
-        env:
-          PLUGIN_NAME: ${{ steps.plugin_name.outputs.plugin_name }}
-        run: |
-          cd ./node_modules/"${PLUGIN_NAME}"
-          pnpm i
-      # Etherpad core dependencies must be installed after installing the
-      # plugin's dependencies, otherwise npm will try to hoist common
-      # dependencies by removing them from src/node_modules and installing them
-      # in the top-level node_modules. As of v6.14.10, npm's hoist logic appears
-      # to be buggy, because it sometimes removes dependencies from
-      # src/node_modules but fails to add them to the top-level node_modules.
-      # Even if npm correctly hoists the dependencies, the hoisting seems to
-      # confuse tools such as `npm outdated`, `npm update`, and some ESLint
-      # rules.
+          pnpm i --no-frozen-lockfile
+          pnpm run build
       -
         name: Install Etherpad core dependencies
+        working-directory: ./etherpad-lite
         run: bin/installDeps.sh
+      - name: Install plugin
+        working-directory: ./etherpad-lite
+        run: |
+          pnpm run plugins i --path ../../plugin
+      - name: Prepare ep_search
+        run: |
+          git clone -b feature/search-engine https://github.com/NII-cloud-operation/ep_search.git /tmp/ep_search
+      - name: Install ep_search
+        working-directory: ./etherpad-lite
+        run: |
+          pnpm run plugins i --path /tmp/ep_search
       - name: Create settings.json
+        working-directory: ./etherpad-lite
         run: cp ./src/tests/settings.json settings.json
       - name: Run the frontend tests
+        working-directory: ./etherpad-lite
         shell: bash
         run: |
-          pnpm run prod &
+          pnpm run dev &
           connected=false
           can_connect() {
-          curl -sSfo /dev/null http://localhost:9001/ || return 1
-          connected=true
+            curl -sSfo /dev/null http://localhost:9001/ || return 1
+            connected=true
           }
           now() { date +%s; }
           start=$(now)
-          while [ $(($(now) - $start)) -le 15 ] && ! can_connect; do
-          sleep 1
+          while [ $(($(now) - $start)) -le 30 ] && ! can_connect; do
+            sleep 1
           done
           cd src
-          pnpm exec playwright install chromium  --with-deps
-          pnpm run test-ui --project=chromium
+          pnpm exec playwright install chromium --with-deps
+          # Excluded tests are Etherpad core tests that are incompatible with
+          # ep_weave's UI changes (see https://github.com/NII-cloud-operation/ep_weave):
+          # - "the share link is the actual pad url": ep_weave rewrites pad URLs to title-based /t/ URLs
+          # - "is an iframe with the correct url parameters and correct size": same reason as above
+          # - "https://etherpad.org/#foo": link insertion behavior differs due to ep_weave's hashview
+          # - "toolbar <li>/<a> wrappers are presentational": ep_weave adds custom toolbar buttons
+          # - "settings popup stays scrollable when the viewport is short": ep_weave modifies pad UI layout
+          # - "Pad-wide font dropdown opens visibly when popup is scrolled to bottom": same reason as above
+          pnpm run test-ui --project=chromium --grep-invert="the share link is the actual pad url|is an iframe with the correct url parameters and correct size|https://etherpad\.org/#foo|toolbar <li>/<a> wrappers are presentational|settings popup stays scrollable when the viewport is short|Pad-wide font dropdown opens visibly when popup is scrolled to bottom"

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -15,10 +15,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ether/etherpad-lite
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: pnpm/action-setup@v3
         name: Install pnpm
         with:
-          version: 8
+          version: 10
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ETHERPAD_IMAGE_NAME="etherpad/etherpad"
-ARG ETHERPAD_IMAGE_TAG="2"
+ARG ETHERPAD_IMAGE_TAG="3"
 
 FROM mcr.microsoft.com/devcontainers/typescript-node:18 AS build-stage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,17 @@ FROM ${ETHERPAD_IMAGE_NAME}:${ETHERPAD_IMAGE_TAG}
 
 USER root
 
-COPY --from=build-stage /app/ep_weave /tmp/ep_weave
+COPY --from=build-stage --chown=etherpad:etherpad /app/ep_weave /tmp/ep_weave
 
 # ep_search
 RUN git clone -b feature/search-engine https://github.com/NII-cloud-operation/ep_search.git /tmp/ep_search \
-    && cd /tmp/ep_search \
-    && ls -la /tmp/ep_search \
-    && npm pack
+    && chown -R etherpad:etherpad /tmp/ep_search \
+    && ls -la /tmp/ep_search
 
 # ep_webrtc
 RUN git clone -b feature/sfu https://github.com/NII-cloud-operation/ep_webrtc.git /tmp/ep_webrtc \
-    && cd /tmp/ep_webrtc \
-    && ls -la /tmp/ep_webrtc \
-    && npm pack
+    && chown -R etherpad:etherpad /tmp/ep_webrtc \
+    && ls -la /tmp/ep_webrtc
 
 USER etherpad
 

--- a/package.json
+++ b/package.json
@@ -14,13 +14,12 @@
     "uuid": "^9.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jquery": "^3.5.30",
     "@types/node": "^20.11.30",
-    "@types/node-fetch": "^2.6.13",
     "eslint": "^8.57.0",
     "eslint-config-etherpad": "^4.0.4",
     "typescript": "^5.4.2"

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -5,6 +5,7 @@ USER root
 COPY . /tmp/ep_weave
 RUN mkdir /opt/ep_weave \
     && mv /tmp/ep_weave/solr /opt/ep_weave/ \
+    && chmod -R a+rX /opt/ep_weave/solr \
     && chmod 0755 /opt/ep_weave/solr/start.sh
 
 USER solr

--- a/src/pad/solr-client.ts
+++ b/src/pad/solr-client.ts
@@ -1,4 +1,3 @@
-import fetch, { Headers } from 'node-fetch';
 
 interface SolrClientConfig {
   baseUrl: string;


### PR DESCRIPTION
This pull request upgrades the base Docker image from Etherpad 2 to Etherpad 3 (currently 3.2.0).

### Changes

* Upgraded base image tag from `"2"` to `"3"` in Dockerfile to resolve the "severely outdated" warning and bring in the latest Etherpad features
* Fixed file ownership for plugin directories (`--chown=etherpad:etherpad` for ep_weave, `chown -R` for ep_search and ep_webrtc) to match the local path installation method
* Replaced `npm pack` with direct local path installation for ep_search and ep_webrtc
* Added `chmod -R a+rX` in solr Dockerfile to fix file readability for the solr user

Verified that ep_weave, ep_search, ep_webrtc, and other plugins load and function correctly on Etherpad 3.