### PR TITLE
Index the pad's last edit time instead of the indexing time

### DIFF
--- a/src/common/@types/ep_search/setup.d.ts
+++ b/src/common/@types/ep_search/setup.d.ts
@@ -19,6 +19,7 @@ declare module "ep_search/setup" {
     setText: (text: string, authorId?: string) => Promise<void>;
     appendText: (text: string) => Promise<void>;
     getHeadRevisionNumber: () => number;
+    getLastEdit: () => Promise<number>;
     getRevisionDate: (rev: number) => Promise<number>;
     getRevisionChangeset: (rev: number) => Promise<AChangeSet>;
     appendRevision: (changeset: AChangeSet, author: string) => Promise<void>;

--- a/src/pad/serializer.ts
+++ b/src/pad/serializer.ts
@@ -4,15 +4,6 @@ import { logPrefix } from "./util/log";
 
 const LENGTH_SHORT_TEXT = 32;
 
-function extractCreated(pad: PadType) {
-  const revs = (pad.savedRevisions || []).map((rev) => rev.timestamp);
-  revs.sort();
-  if (revs.length === 0) {
-    return null;
-  }
-  return new Date(revs[0]).toISOString();
-}
-
 function extractShortText(text: string) {
   const titleIndex = text.indexOf("\n");
   let atext = text;
@@ -24,20 +15,12 @@ function extractShortText(text: string) {
     : atext;
 }
 
-exports.create = (pluginSettings: any) => (pad: PadType) => {
+exports.create = (pluginSettings: any) => async (pad: PadType) => {
   const atext = (pad.atext || {}).text || "";
   const shorttext = extractShortText(atext);
-  const result: {
-    indexed: string;
-    id: string;
-    _text_: string;
-    atext: string;
-    title: string;
-    hash: string;
-    shorttext: string;
-    created?: string;
-  } = {
-    indexed: new Date().toISOString(),
+  const result = {
+    indexed: new Date(await pad.getLastEdit()).toISOString(),
+    created: new Date(await pad.getRevisionDate(0)).toISOString(),
     id: pad.id,
     _text_: atext,
     atext,
@@ -45,10 +28,6 @@ exports.create = (pluginSettings: any) => (pad: PadType) => {
     hash: atext,
     shorttext,
   };
-  const created = extractCreated(pad);
-  if (created !== null) {
-    result.created = created;
-  }
   console.debug(logPrefix, "serialize", pad, result);
   return result;
 };

--- a/tests/e2e/migration/10_Create_Pad.ipynb
+++ b/tests/e2e/migration/10_Create_Pad.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c0",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
    "outputs": [],
    "source": [
     "etherpad_url = \"http://localhost:9001/\"\n",

--- a/tests/e2e/migration/10_Create_Pad.ipynb
+++ b/tests/e2e/migration/10_Create_Pad.ipynb
@@ -15,7 +15,8 @@
     "migration_pad_title = \"Solr Migration Test Pad\"\n",
     "default_result_path = None\n",
     "close_on_fail = False\n",
-    "transition_timeout = 10000"
+    "transition_timeout = 10000\n",
+    "indexed_record_path = None"
    ]
   },
   {
@@ -145,6 +146,52 @@
     "    return index_page\n",
     "\n",
     "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "idx-md",
+   "metadata": {},
+   "source": [
+    "## Record the indexed timestamp of the pad.\n",
+    "\n",
+    "The search index must stamp `indexed` with the pad's last-edit time. Record it for the post-migration check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "idx-rec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.parse\n",
+    "\n",
+    "pad_indexed = None\n",
+    "\n",
+    "async def _step(page):\n",
+    "    query = urllib.parse.quote(f'title:\"{migration_pad_title}\"')\n",
+    "    response = await page.request.get(f\"{etherpad_url}search/?query={query}\")\n",
+    "    assert response.ok, response.status\n",
+    "    result = await response.json()\n",
+    "    assert result[\"numFound\"] == 1, result\n",
+    "    global pad_indexed\n",
+    "    pad_indexed = result[\"docs\"][0][\"indexed\"]\n",
+    "\n",
+    "await run_pw(_step)\n",
+    "pad_indexed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "idx-save",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if indexed_record_path:\n",
+    "    with open(indexed_record_path, \"w\") as f:\n",
+    "        f.write(pad_indexed)"
    ]
   },
   {

--- a/tests/e2e/migration/20_Verify_Broken.ipynb
+++ b/tests/e2e/migration/20_Verify_Broken.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c0",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
    "outputs": [],
    "source": [
     "etherpad_url = \"http://localhost:9001/\"\n",

--- a/tests/e2e/migration/30_Verify_Recovered.ipynb
+++ b/tests/e2e/migration/30_Verify_Recovered.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c0",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
    "outputs": [],
    "source": [
     "etherpad_url = \"http://localhost:9001/\"\n",

--- a/tests/e2e/migration/30_Verify_Recovered.ipynb
+++ b/tests/e2e/migration/30_Verify_Recovered.ipynb
@@ -15,7 +15,8 @@
     "migration_pad_title = \"Solr Migration Test Pad\"\n",
     "default_result_path = None\n",
     "close_on_fail = False\n",
-    "transition_timeout = 10000"
+    "transition_timeout = 10000\n",
+    "indexed_record_path = None"
    ]
   },
   {
@@ -116,6 +117,41 @@
     "    await index_page.locator(\".hashview-search-box\").fill(f'\"{migration_pad_title}\"')\n",
     "    await index_page.keyboard.press(\"Enter\")\n",
     "    await expect(index_page.locator('.hash-link')).to_have_count(1, timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "idx-md",
+   "metadata": {},
+   "source": [
+    "## The indexed timestamp survives the reindex.\n",
+    "\n",
+    "Reindexing must restore the pad's last-edit time, not stamp the reindex time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "idx-verify",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.parse\n",
+    "\n",
+    "assert indexed_record_path, \"indexed_record_path is required\"\n",
+    "with open(indexed_record_path) as f:\n",
+    "    expected_indexed = f.read()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    query = urllib.parse.quote(f'title:\"{migration_pad_title}\"')\n",
+    "    response = await page.request.get(f\"{etherpad_url}search/?query={query}\")\n",
+    "    assert response.ok, response.status\n",
+    "    result = await response.json()\n",
+    "    assert result[\"numFound\"] == 1, result\n",
+    "    indexed = result[\"docs\"][0][\"indexed\"]\n",
+    "    assert indexed == expected_indexed, (indexed, expected_indexed)\n",
     "\n",
     "await run_pw(_step)"
    ]

--- a/tests/e2e/migration/run.sh
+++ b/tests/e2e/migration/run.sh
@@ -11,12 +11,14 @@ RESULT_DIR="${RESULT_DIR:-tests/e2e/artifacts/migration}"
 TRANSITION_TIMEOUT="${E2E_TRANSITION_TIMEOUT:-30000}"
 export ETHERPAD_URL="${ETHERPAD_URL:-http://localhost:9001/health}"
 mkdir -p "${RESULT_DIR}"
+INDEXED_RECORD_PATH="$(cd "${RESULT_DIR}" && pwd)/pad-indexed.txt"
 
 run_nb() {
   python3 -m papermill "tests/e2e/migration/$1.ipynb" "${RESULT_DIR}/$1-result.ipynb" \
     --cwd tests/e2e/notebooks \
     -p etherpad_url "${ETHERPAD_URL%health}" \
-    -p transition_timeout "${TRANSITION_TIMEOUT}"
+    -p transition_timeout "${TRANSITION_TIMEOUT}" \
+    -p indexed_record_path "${INDEXED_RECORD_PATH}"
 }
 
 docker compose ${OLD} up -d --build


### PR DESCRIPTION
The `indexed` field was stamped with `new Date()` at serialization time, so reindexing after a Solr volume wipe overwrote every pad's timestamp with the reindex time, breaking the "Date modified" ordering on the top page. The serializer now derives `indexed` from the pad's head revision timestamp and `created` from revision 0, so both survive a reindex. Requires NII-cloud-operation/ep_search#3 (merged).

- Stamp `indexed` with `await pad.getLastEdit()` and `created` with `await pad.getRevisionDate(0)` in the serializer
- Extend the Solr volume migration E2E to record the pad's `indexed` timestamp before migration and assert it survives the reindex
- Fix papermill parameter injection in the migration notebooks by tagging the parameters cell (previously `-p` overrides such as `transition_timeout` were silently ignored)

Verified locally with the full migration E2E flow: `indexed` survives a volume wipe unchanged, and the old behavior fails the new assertion with the reindex time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)